### PR TITLE
Add module with tests and gh workflow

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,11 +1,11 @@
-name: Build
+name: Verify
 
 on:
   pull_request:
     branches: [ main ]
 
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,5 +23,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build
-        run: mvn --batch-mode install
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+
+      - name: Verify
+        run: mvn verify -P integration

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <module>test-frame-common</module>
         <module>test-frame-kubernetes</module>
         <module>test-frame-openshift</module>
+        <module>test-frame-test</module>
     </modules>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <fabric8.version>6.5.1</fabric8.version>
+        <fabric8.version>6.10.0</fabric8.version>
 
         <maven.spotbugs.version>4.7.3.4</maven.spotbugs.version>
         <maven.checkstyle.version>3.3.0</maven.checkstyle.version>
@@ -90,6 +90,8 @@
         <maven.plugin.plugin.version>3.9.0</maven.plugin.plugin.version>
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.platform.version>1.10.2</junit.platform.version>
+        <maven.surefire.version>3.2.2</maven.surefire.version>
     </properties>
 
     <dependencyManagement>
@@ -130,9 +132,44 @@
                 <version>${fabric8.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-server-mock</artifactId>
+                <version>${fabric8.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
                 <version>${junit.jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit.jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>${junit.platform.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>${junit.platform.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>${junit.platform.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceAccountResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceAccountResource.java
@@ -9,12 +9,12 @@ import java.util.function.Consumer;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import io.skodjob.testframe.interfaces.NamespacedResourceType;
 
 public class ServiceAccountResource implements NamespacedResourceType<ServiceAccount> {
 
-    private final MixedOperation<ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> client;
+    private final MixedOperation<ServiceAccount, ServiceAccountList,
+            io.fabric8.kubernetes.client.dsl.ServiceAccountResource> client;
 
     public ServiceAccountResource() {
         this.client = ResourceManager.getKubeClient().getClient().serviceAccounts();

--- a/test-frame-test/pom.xml
+++ b/test-frame-test/pom.xml
@@ -119,16 +119,6 @@
 
     <profiles>
         <profile>
-            <id>none</id>
-            <properties>
-                <it.skip>true</it.skip>
-            </properties>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-        </profile>
-
-        <profile>
             <id>integration</id>
             <properties>
                 <it.skip>false</it.skip>

--- a/test-frame-test/pom.xml
+++ b/test-frame-test/pom.xml
@@ -79,6 +79,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
                 <configuration>
                     <test>io.skodjob.testframe.test.unit.**</test>
                     <properties>
@@ -91,6 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/test-frame-test/pom.xml
+++ b/test-frame-test/pom.xml
@@ -16,11 +16,6 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
-        <junit.platform.version>1.10.2</junit.platform.version>
-        <maven.surefire.version>3.2.2</maven.surefire.version>
-        <fabric8.version>6.10.0</fabric8.version>
-
         <maven.deploy.skip>true</maven.deploy.skip>
         <it.skip>true</it.skip>
     </properties>
@@ -45,44 +40,36 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
-            <version>${fabric8.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-commons</artifactId>
-            <version>${junit.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-engine</artifactId>
-            <version>${junit.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${maven.surefire.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -92,7 +79,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.version}</version>
                 <configuration>
                     <test>io.skodjob.testframe.test.unit.**</test>
                     <properties>
@@ -105,7 +91,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven.surefire.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/test-frame-test/pom.xml
+++ b/test-frame-test/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.skodjob</groupId>
+        <artifactId>test-frame</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>test-frame-test</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.platform.version>1.10.2</junit.platform.version>
+        <maven.surefire.version>3.2.2</maven.surefire.version>
+        <fabric8.version>6.10.0</fabric8.version>
+
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <it.skip>true</it.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.skodjob</groupId>
+            <artifactId>test-frame-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>generator-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <version>${fabric8.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-commons</artifactId>
+            <version>${junit.platform.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${junit.platform.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
+            <version>${junit.platform.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${maven.surefire.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <configuration>
+                    <test>io.skodjob.testframe.test.unit.**</test>
+                    <properties>
+                        <configurationParameters>
+                            junit.jupiter.extensions.autodetection.enabled = true
+                        </configurationParameters>
+                    </properties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>verify</goal>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipITs>${it.skip}</skipITs>
+                    <forkCount>0</forkCount>
+                    <includes>
+                        <include>io.skodjob.testframe.test.integration.**</include>
+                    </includes>
+                    <properties>
+                        <configurationParameters>
+                            junit.jupiter.extensions.autodetection.enabled = true
+                        </configurationParameters>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>none</id>
+            <properties>
+                <it.skip>true</it.skip>
+            </properties>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+
+        <profile>
+            <id>integration</id>
+            <properties>
+                <it.skip>false</it.skip>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/test-frame-test/src/test/java/io/skodjob/testframe/test/integration/ResourceManagerIT.java
+++ b/test-frame-test/src/test/java/io/skodjob/testframe/test/integration/ResourceManagerIT.java
@@ -5,6 +5,8 @@
 package io.skodjob.testframe.test.integration;
 
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.skodjob.testframe.annotations.TestVisualSeparator;
+import io.skodjob.testframe.clients.KubeClusterException;
 import io.skodjob.testframe.resources.ResourceManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,8 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @io.skodjob.testframe.annotations.ResourceManager
+@TestVisualSeparator
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ResourceManagerIT {
 
@@ -30,8 +35,22 @@ public class ResourceManagerIT {
     }
 
     @Test
-    void test() {
+    void createResource() {
+        ResourceManager.getInstance().createResourceWithWait(
+                new NamespaceBuilder().withNewMetadata().withName("test3").endMetadata().build());
+    }
+
+    @Test
+    void testKubeClientNamespacesExists() {
         assertNotNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test").get());
         assertNotNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
+        assertNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test3").get());
+    }
+
+    @Test
+    void testKubeCmdClientNamespacesExists() {
+        assertNotNull(ResourceManager.getKubeCmdClient().get("namespace", "test"));
+        assertNotNull(ResourceManager.getKubeCmdClient().get("namespace", "test2"));
+        assertThrows(KubeClusterException.class, () -> ResourceManager.getKubeCmdClient().get("namespace", "test3"));
     }
 }

--- a/test-frame-test/src/test/java/io/skodjob/testframe/test/integration/ResourceManagerIT.java
+++ b/test-frame-test/src/test/java/io/skodjob/testframe/test/integration/ResourceManagerIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.testframe.annotations.TestVisualSeparator;
 import io.skodjob.testframe.clients.KubeClusterException;
 import io.skodjob.testframe.resources.ResourceManager;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,12 @@ public class ResourceManagerIT {
     void setupEach() {
         ResourceManager.getInstance().createResourceWithWait(
                 new NamespaceBuilder().withNewMetadata().withName("test2").endMetadata().build());
+    }
+
+    @AfterAll
+    void afterAll() {
+        assertNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
+        assertNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test3").get());
     }
 
     @Test

--- a/test-frame-test/src/test/java/io/skodjob/testframe/test/integration/ResourceManagerIT.java
+++ b/test-frame-test/src/test/java/io/skodjob/testframe/test/integration/ResourceManagerIT.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe.test.integration;
+
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.skodjob.testframe.resources.ResourceManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@io.skodjob.testframe.annotations.ResourceManager
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ResourceManagerIT {
+
+    @BeforeAll
+    void setupAll() {
+        ResourceManager.getInstance().createResourceWithWait(
+                new NamespaceBuilder().withNewMetadata().withName("test").endMetadata().build());
+    }
+
+    @BeforeEach
+    void setupEach() {
+        ResourceManager.getInstance().createResourceWithWait(
+                new NamespaceBuilder().withNewMetadata().withName("test2").endMetadata().build());
+    }
+
+    @Test
+    void test() {
+        assertNotNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test").get());
+        assertNotNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
+    }
+}

--- a/test-frame-test/src/test/java/io/skodjob/testframe/test/unit/UnitTests.java
+++ b/test-frame-test/src/test/java/io/skodjob/testframe/test/unit/UnitTests.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe.test.unit;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+@EnableKubernetesMockClient(crud = true)
+public class UnitTests {
+    private KubernetesClient kubernetesClient;
+    private KubernetesMockServer server;
+
+    @Test
+    void tmpTest() {
+        System.out.println("Placeholder for test");
+    }
+}

--- a/test-frame-test/src/test/java/io/skodjob/testframe/test/unit/UnitTests.java
+++ b/test-frame-test/src/test/java/io/skodjob/testframe/test/unit/UnitTests.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Test;
 
+//TODO Implement mock kube to be able to work with RM
 @EnableKubernetesMockClient(crud = true)
 public class UnitTests {
     private KubernetesClient kubernetesClient;


### PR DESCRIPTION
1. Fix dependencies across modules
2. Add module with tests (it will not be released into mvn packages)
3. Update to fabric8 6.10 across all modules
4. Adds workflow for running integration tests against kind

NOTE: Running against mock kube server will be done in scope of different PR