### PR TITLE
Rename ResourceManager to avoid import conflicts

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/listeners/ResourceManagerCleanerExtension.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/listeners/ResourceManagerCleanerExtension.java
@@ -4,7 +4,7 @@
  */
 package io.skodjob.testframe.listeners;
 
-import io.skodjob.testframe.resources.ResourceManager;
+import io.skodjob.testframe.resources.KubeResourceManager;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -17,13 +17,13 @@ public class ResourceManagerCleanerExtension
 
     @Override
     public void afterAll(ExtensionContext extensionContext) {
-        ResourceManager.setTestContext(extensionContext);
-        ResourceManager.getInstance().deleteResources();
+        KubeResourceManager.setTestContext(extensionContext);
+        KubeResourceManager.getInstance().deleteResources();
     }
 
     @Override
     public void afterEach(ExtensionContext extensionContext) {
-        ResourceManager.setTestContext(extensionContext);
-        ResourceManager.getInstance().deleteResources();
+        KubeResourceManager.setTestContext(extensionContext);
+        KubeResourceManager.getInstance().deleteResources();
     }
 }

--- a/test-frame-common/src/main/java/io/skodjob/testframe/listeners/ResourceManagerExtension.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/listeners/ResourceManagerExtension.java
@@ -4,7 +4,7 @@
  */
 package io.skodjob.testframe.listeners;
 
-import io.skodjob.testframe.resources.ResourceManager;
+import io.skodjob.testframe.resources.KubeResourceManager;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -19,22 +19,22 @@ public class ResourceManagerExtension
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
-        ResourceManager.getInstance();
-        ResourceManager.setTestContext(extensionContext);
+        KubeResourceManager.getInstance();
+        KubeResourceManager.setTestContext(extensionContext);
     }
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) {
-        ResourceManager.setTestContext(extensionContext);
+        KubeResourceManager.setTestContext(extensionContext);
     }
 
     @Override
     public void afterAll(ExtensionContext extensionContext) {
-        ResourceManager.setTestContext(extensionContext);
+        KubeResourceManager.setTestContext(extensionContext);
     }
 
     @Override
     public void afterEach(ExtensionContext extensionContext) {
-        ResourceManager.setTestContext(extensionContext);
+        KubeResourceManager.setTestContext(extensionContext);
     }
 }

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -26,10 +26,10 @@ import org.slf4j.LoggerFactory;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ResourceManager {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceManager.class);
+public class KubeResourceManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KubeResourceManager.class);
 
-    private static ResourceManager instance;
+    private static KubeResourceManager instance;
     private static KubeClient client;
     private static KubeCmdClient kubeCmdClient;
 
@@ -37,9 +37,9 @@ public class ResourceManager {
 
     private static final Map<String, Stack<ResourceItem>> STORED_RESOURCES = new LinkedHashMap<>();
 
-    public static synchronized ResourceManager getInstance() {
+    public static synchronized KubeResourceManager getInstance() {
         if (instance == null) {
-            instance = new ResourceManager();
+            instance = new KubeResourceManager();
             instance.resourceTypes = new ResourceType[]{};
             client = new KubeClient();
             if (TestFrameEnv.CLIENT_TYPE.equals(TestFrameConstants.KUBERNETES_CLIENT)) {

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleBindingResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleBindingResource.java
@@ -18,7 +18,7 @@ public class ClusterRoleBindingResource implements ResourceType<ClusterRoleBindi
             Resource<ClusterRoleBinding>> client;
 
     public ClusterRoleBindingResource() {
-        this.client = ResourceManager.getKubeClient().getClient().rbac().clusterRoleBindings();
+        this.client = KubeResourceManager.getKubeClient().getClient().rbac().clusterRoleBindings();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleResource.java
@@ -17,7 +17,7 @@ public class ClusterRoleResource implements ResourceType<ClusterRole> {
     private final NonNamespaceOperation<ClusterRole, ClusterRoleList, Resource<ClusterRole>> client;
 
     public ClusterRoleResource() {
-        this.client = ResourceManager.getKubeClient().getClient().rbac().clusterRoles();
+        this.client = KubeResourceManager.getKubeClient().getClient().rbac().clusterRoles();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ConfigMapResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ConfigMapResource.java
@@ -16,7 +16,7 @@ public class ConfigMapResource implements NamespacedResourceType<ConfigMap> {
     private final MixedOperation<ConfigMap, ConfigMapList, Resource<ConfigMap>> client;
 
     public ConfigMapResource() {
-        this.client = ResourceManager.getKubeClient().getClient().configMaps();
+        this.client = KubeResourceManager.getKubeClient().getClient().configMaps();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/CustomResourceDefinitionResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/CustomResourceDefinitionResource.java
@@ -18,7 +18,7 @@ public class CustomResourceDefinitionResource implements ResourceType<CustomReso
             Resource<CustomResourceDefinition>> client;
 
     public CustomResourceDefinitionResource() {
-        this.client = ResourceManager.getKubeClient().getClient().apiextensions().v1().customResourceDefinitions();
+        this.client = KubeResourceManager.getKubeClient().getClient().apiextensions().v1().customResourceDefinitions();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/DeploymentResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/DeploymentResource.java
@@ -17,7 +17,7 @@ public class DeploymentResource implements NamespacedResourceType<Deployment> {
     private final MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> client;
 
     public DeploymentResource() {
-        this.client = ResourceManager.getKubeClient().getClient().apps().deployments();
+        this.client = KubeResourceManager.getKubeClient().getClient().apps().deployments();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/JobResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/JobResource.java
@@ -17,7 +17,7 @@ public class JobResource implements NamespacedResourceType<Job> {
     private final MixedOperation<Job, JobList, ScalableResource<Job>> client;
 
     public JobResource() {
-        this.client = ResourceManager.getKubeClient().getClient().batch().v1().jobs();
+        this.client = KubeResourceManager.getKubeClient().getClient().batch().v1().jobs();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/LeaseResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/LeaseResource.java
@@ -17,7 +17,7 @@ public class LeaseResource implements NamespacedResourceType<Lease> {
     private MixedOperation<Lease, LeaseList, Resource<Lease>> client;
 
     public LeaseResource() {
-        this.client = ResourceManager.getKubeClient().getClient().leases();
+        this.client = KubeResourceManager.getKubeClient().getClient().leases();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NamespaceResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NamespaceResource.java
@@ -18,7 +18,7 @@ public class NamespaceResource implements ResourceType<Namespace> {
     private final NonNamespaceOperation<Namespace, NamespaceList, Resource<Namespace>> client;
 
     public NamespaceResource() {
-        this.client = ResourceManager.getKubeClient().getClient().namespaces();
+        this.client = KubeResourceManager.getKubeClient().getClient().namespaces();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NetworkPolicyResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NetworkPolicyResource.java
@@ -17,7 +17,7 @@ public class NetworkPolicyResource implements NamespacedResourceType<NetworkPoli
     private final MixedOperation<NetworkPolicy, NetworkPolicyList, Resource<NetworkPolicy>> client;
 
     public NetworkPolicyResource() {
-        this.client = ResourceManager.getKubeClient().getClient().network().networkPolicies();
+        this.client = KubeResourceManager.getKubeClient().getClient().network().networkPolicies();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleBindingResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleBindingResource.java
@@ -17,7 +17,7 @@ public class RoleBindingResource implements NamespacedResourceType<RoleBinding> 
     private final MixedOperation<RoleBinding, RoleBindingList, Resource<RoleBinding>> client;
 
     public RoleBindingResource() {
-        this.client = ResourceManager.getKubeClient().getClient().rbac().roleBindings();
+        this.client = KubeResourceManager.getKubeClient().getClient().rbac().roleBindings();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleResource.java
@@ -17,7 +17,7 @@ public class RoleResource implements NamespacedResourceType<Role> {
     private final MixedOperation<Role, RoleList, Resource<Role>> client;
 
     public RoleResource() {
-        this.client = ResourceManager.getKubeClient().getClient().rbac().roles();
+        this.client = KubeResourceManager.getKubeClient().getClient().rbac().roles();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/SecretResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/SecretResource.java
@@ -17,7 +17,7 @@ public class SecretResource implements NamespacedResourceType<Secret> {
     private final MixedOperation<Secret, SecretList, Resource<Secret>> client;
 
     public SecretResource() {
-        this.client = ResourceManager.getKubeClient().getClient().secrets();
+        this.client = KubeResourceManager.getKubeClient().getClient().secrets();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceAccountResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceAccountResource.java
@@ -17,7 +17,7 @@ public class ServiceAccountResource implements NamespacedResourceType<ServiceAcc
             io.fabric8.kubernetes.client.dsl.ServiceAccountResource> client;
 
     public ServiceAccountResource() {
-        this.client = ResourceManager.getKubeClient().getClient().serviceAccounts();
+        this.client = KubeResourceManager.getKubeClient().getClient().serviceAccounts();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceResource.java
@@ -17,7 +17,7 @@ public class ServiceResource implements NamespacedResourceType<Service> {
             io.fabric8.kubernetes.client.dsl.ServiceResource<Service>> client;
 
     public ServiceResource() {
-        this.client = ResourceManager.getKubeClient().getClient().services();
+        this.client = KubeResourceManager.getKubeClient().getClient().services();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ValidatingWebhookConfigurationResource.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ValidatingWebhookConfigurationResource.java
@@ -19,7 +19,7 @@ public class ValidatingWebhookConfigurationResource implements ResourceType<Vali
             Resource<ValidatingWebhookConfiguration>> client;
 
     public ValidatingWebhookConfigurationResource() {
-        this.client = ResourceManager.getKubeClient().getClient()
+        this.client = KubeResourceManager.getKubeClient().getClient()
                 .admissionRegistration()
                 .v1()
                 .validatingWebhookConfigurations();

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/OperatorGroupResource.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/OperatorGroupResource.java
@@ -17,7 +17,7 @@ public class OperatorGroupResource implements NamespacedResourceType<OperatorGro
     private final MixedOperation<OperatorGroup, OperatorGroupList, Resource<OperatorGroup>> client;
 
     public OperatorGroupResource() {
-        this.client = ResourceManager.getKubeClient().getOpenShiftClient().operatorHub().operatorGroups();
+        this.client = KubeResourceManager.getKubeClient().getOpenShiftClient().operatorHub().operatorGroups();
     }
 
     /**

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/SubscriptionResource.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/SubscriptionResource.java
@@ -17,7 +17,7 @@ public class SubscriptionResource implements NamespacedResourceType<Subscription
     private final MixedOperation<Subscription, SubscriptionList, Resource<Subscription>> client;
 
     public SubscriptionResource() {
-        this.client = ResourceManager.getKubeClient().getOpenShiftClient().operatorHub().subscriptions();
+        this.client = KubeResourceManager.getKubeClient().getOpenShiftClient().operatorHub().subscriptions();
     }
 
     /**

--- a/test-frame-test/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
+++ b/test-frame-test/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
@@ -5,9 +5,10 @@
 package io.skodjob.testframe.test.integration;
 
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.skodjob.testframe.annotations.ResourceManager;
 import io.skodjob.testframe.annotations.TestVisualSeparator;
 import io.skodjob.testframe.clients.KubeClusterException;
-import io.skodjob.testframe.resources.ResourceManager;
+import io.skodjob.testframe.resources.KubeResourceManager;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,46 +19,46 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@io.skodjob.testframe.annotations.ResourceManager
+@ResourceManager
 @TestVisualSeparator
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ResourceManagerIT {
+public class KubeResourceManagerIT {
 
     @BeforeAll
     void setupAll() {
-        ResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.getInstance().createResourceWithWait(
                 new NamespaceBuilder().withNewMetadata().withName("test").endMetadata().build());
     }
 
     @BeforeEach
     void setupEach() {
-        ResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.getInstance().createResourceWithWait(
                 new NamespaceBuilder().withNewMetadata().withName("test2").endMetadata().build());
     }
 
     @AfterAll
     void afterAll() {
-        assertNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
-        assertNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test3").get());
+        assertNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
+        assertNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test3").get());
     }
 
     @Test
     void createResource() {
-        ResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.getInstance().createResourceWithWait(
                 new NamespaceBuilder().withNewMetadata().withName("test3").endMetadata().build());
     }
 
     @Test
     void testKubeClientNamespacesExists() {
-        assertNotNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test").get());
-        assertNotNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
-        assertNull(ResourceManager.getKubeClient().getClient().namespaces().withName("test3").get());
+        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test").get());
+        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
+        assertNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test3").get());
     }
 
     @Test
     void testKubeCmdClientNamespacesExists() {
-        assertNotNull(ResourceManager.getKubeCmdClient().get("namespace", "test"));
-        assertNotNull(ResourceManager.getKubeCmdClient().get("namespace", "test2"));
-        assertThrows(KubeClusterException.class, () -> ResourceManager.getKubeCmdClient().get("namespace", "test3"));
+        assertNotNull(KubeResourceManager.getKubeCmdClient().get("namespace", "test"));
+        assertNotNull(KubeResourceManager.getKubeCmdClient().get("namespace", "test2"));
+        assertThrows(KubeClusterException.class, () -> KubeResourceManager.getKubeCmdClient().get("namespace", "test3"));
     }
 }


### PR DESCRIPTION
The recent addition of the `ResourceManager` annotation brought unexpected inconvenience.
The annotation had precisely the same signature as the `ResourceManager` class. This situation would force potential users to
use fully qualified import on either annotation or the actual implementation. 


To resolve this problem, PR renames implementation to `KubeResourceManager`.