### PR TITLE
Style changes + namespace related methods renaming and changes

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/LoggerUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/LoggerUtils.java
@@ -56,7 +56,7 @@ public class LoggerUtils {
      * @param resource resource
      * @param <T> The type of the resources.
      */
-    public static <T extends HasMetadata>  void  logResource(String operation, T resource) {
+    public static <T extends HasMetadata> void logResource(String operation, T resource) {
         if (resource.getMetadata().getNamespace() == null) {
             LOGGER.info(LoggerUtils.RESOURCE_LOGGER_PATTERN,
                     operation, resource.getKind(),

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClient.java
@@ -95,7 +95,11 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     }
 
     protected List<String> namespacedCommand(String... rest) {
-        return command(asList(rest), true);
+        List<String> result = command(asList(rest));
+        result.add("--namespace");
+        result.add(namespace);
+
+        return result;
     }
 
     /**
@@ -268,7 +272,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @SuppressWarnings("unchecked")
     public K applyContent(String yamlContent) {
         try (Context context = defaultContext()) {
-            Exec.exec(yamlContent, command(Arrays.asList(APPLY, "-f", "-"), false), 0,
+            Exec.exec(yamlContent, command(Arrays.asList(APPLY, "-f", "-")), 0,
                     true, true);
             return (K) this;
         }
@@ -284,7 +288,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @SuppressWarnings("unchecked")
     public K deleteContent(String yamlContent) {
         try (Context context = defaultContext()) {
-            Exec.exec(yamlContent, command(Arrays.asList(DELETE, "-f", "-"), false), 0,
+            Exec.exec(yamlContent, command(Arrays.asList(DELETE, "-f", "-")), 0,
                     true, false);
             return (K) this;
         }
@@ -413,7 +417,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
      */
     @Override
     public ExecResult exec(boolean throwError, boolean logToOutput, String... command) {
-        List<String> cmd = command(asList(command), false);
+        List<String> cmd = command(asList(command));
         return Exec.exec(null, cmd, 0, logToOutput, throwError);
     }
 
@@ -428,7 +432,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
      */
     @Override
     public ExecResult exec(boolean throwError, boolean logToOutput, int timeout, String... command) {
-        List<String> cmd = command(asList(command), false);
+        List<String> cmd = command(asList(command));
         return Exec.exec(null, cmd, timeout, logToOutput, throwError);
     }
 
@@ -630,17 +634,15 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
                 .out().split("\\s+"));
     }
 
-    private List<String> command(List<String> rest, boolean namespaced) {
+    private List<String> command(List<String> rest) {
         List<String> result = new ArrayList<>();
         result.add(cmd());
+
         if (config != null) {
             result.add("--kubeconfig");
             result.add(config);
         }
-        if (namespaced) {
-            result.add("--namespace");
-            result.add(namespace);
-        }
+
         result.addAll(rest);
         return result;
     }
@@ -656,10 +658,11 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @Override
     @SuppressWarnings("unchecked")
     public K process(Map<String, String> parameters, String file, Consumer<String> c) {
-        List<String> command = command(asList(PROCESS, "-f", file), false);
+        List<String> command = command(asList(PROCESS, "-f", file));
         command.addAll(parameters.entrySet().stream()
                 .map(e -> "-p " + e.getKey() + "=" + e.getValue())
-                .collect(Collectors.toList()));
+                .toList());
+
         c.accept(Exec.exec(null, command, 0, false).out());
         return (K) this;
     }

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClient.java
@@ -95,11 +95,10 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     }
 
     protected List<String> namespacedCommand(String... rest) {
-        List<String> result = command(asList(rest));
-        result.add("--namespace");
-        result.add(namespace);
+        List<String> cmd = new ArrayList<>(List.of("--namespace", namespace));
+        cmd.addAll(asList(rest));
 
-        return result;
+        return command(cmd);
     }
 
     /**

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
@@ -48,14 +48,14 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      * @param namespace The namespace to set.
      * @return This kube client.
      */
-    KubeCmdClient<K> namespace(String namespace);
+    KubeCmdClient<K> inNamespace(String namespace);
 
     /**
      * Retrieves the currently set namespace for the Kubernetes client.
      *
      * @return The currently set namespace.
      */
-    String namespace();
+    String getCurrentNamespace();
 
     /**
      * Creates resources from the provided files.

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Kubectl.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Kubectl.java
@@ -42,7 +42,7 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
      * @return A new Kubectl instance with the specified namespace.
      */
     @Override
-    public Kubectl namespace(String namespace) {
+    public Kubectl inNamespace(String namespace) {
         return new Kubectl(namespace, config);
     }
 
@@ -52,7 +52,7 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
      * @return The current namespace.
      */
     @Override
-    public String namespace() {
+    public String getCurrentNamespace() {
         return namespace;
     }
 

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Oc.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Oc.java
@@ -67,7 +67,7 @@ public class Oc extends BaseCmdKubeClient<Oc> {
      * @return A new Oc instance with the specified namespace.
      */
     @Override
-    public Oc namespace(String namespace) {
+    public Oc inNamespace(String namespace) {
         return new Oc(namespace, config);
     }
 
@@ -77,7 +77,7 @@ public class Oc extends BaseCmdKubeClient<Oc> {
      * @return The current namespace.
      */
     @Override
-    public String namespace() {
+    public String getCurrentNamespace() {
         return namespace;
     }
 


### PR DESCRIPTION
This PR:

- does style changes (removing extra spaces and converting `.collect(Collectors.toList()));` to `toList();`)
- changes the way how the `namespacedCommand` is written -> the `command` contains parameter `boolean namespaced` which is needed just for one case -> in the `namespacedCommand` -> so this PR little bit refactors this
- renaming confusing methods `namespace()` and `namespace()` in the clients, as both of the methods does something completely different