### PR TITLE
Add methods and classes related to installation of the deployment/operators

### DIFF
--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/enums/InstallType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/enums/InstallType.java
@@ -5,15 +5,25 @@
 package io.skodjob.testframe.enums;
 
 /**
- * Enum class containing names of installation methods for deployments (and operators):
- *      - Bundle (installation using YAML files)
- *      - Helm (installation using Helm charts)
- *      - OLM (installation using container catalog on the OperatorHub)
+ * Enum class containing names of installation methods for deployments (and operators)
  */
 public enum InstallType {
+    /**
+     * Bundle installation type - installation using YAML files
+     */
     Bundle,
+    /**
+     * Helm installation type - installation using Helm charts
+     */
     Helm,
+    /**
+     * OLM installation type - installation using container catalog on the OperatorHub
+     */
     Olm,
+    /**
+     * Unknown installation type - returned in case that the installation type provided is not
+     * one of the above
+     */
     Unknown;
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/enums/InstallType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/enums/InstallType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe.enums;
+
+/**
+ * Enum class containing names of installation methods for deployments (and operators):
+ *      - Bundle (installation using YAML files)
+ *      - Helm (installation using Helm charts)
+ *      - OLM (installation using container catalog on the OperatorHub)
+ */
+public enum InstallType {
+    Bundle,
+    Helm,
+    Olm,
+    Unknown;
+
+    /**
+     * Returns enum based on String
+     *
+     * @param text  installation method in String
+     *
+     * @return one of the enums or {@link #Unknown} in case of not supported install type
+     */
+    public static InstallType fromString(String text) {
+        for (InstallType installType : InstallType.values()) {
+            if (installType.toString().equalsIgnoreCase(text)) {
+                return installType;
+            }
+        }
+        return Unknown;
+    }
+}

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/enums/InstallType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/enums/InstallType.java
@@ -9,9 +9,9 @@ package io.skodjob.testframe.enums;
  */
 public enum InstallType {
     /**
-     * Bundle installation type - installation using YAML files
+     * Yaml installation type - installation using YAML files
      */
-    Bundle,
+    Yaml,
     /**
      * Helm installation type - installation using Helm charts
      */

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/installation/InstallationMethod.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/installation/InstallationMethod.java
@@ -11,7 +11,7 @@ public abstract class InstallationMethod {
     /**
      * Deploy deployment/operator abstract method
      */
-    public abstract void deploy();
+    public abstract void install();
 
     /**
      * Delete deployment/operator abstract method

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/installation/InstallationMethod.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/installation/InstallationMethod.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe.installation;
+
+/**
+ * Abstract class containing methods that can be implemented in particular setup classes based on the installation type.
+ */
+public abstract class InstallationMethod {
+    /**
+     * Deploy deployment/operator abstract method
+     */
+    public abstract void deploy();
+
+    /**
+     * Delete deployment/operator abstract method
+     */
+    public abstract void delete();
+}


### PR DESCRIPTION
This PR adds classes that can be useful for those who are writing some setup classes for their deployments or operators.
It provides basic installation types like bundle, Helm, OLM.