### PR TITLE
Create TestEnvironmentVariables object for storing the env vars in each test suite

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/TestFrameEnv.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/TestFrameEnv.java
@@ -4,30 +4,15 @@
  */
 package io.skodjob.testframe;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.yaml.snakeyaml.Yaml;
+import io.skodjob.testframe.environment.TestEnvironmentVariables;
 
 /**
  * Class which holds environment variables for system tests.
  */
 public final class TestFrameEnv {
 
-    private static final Logger LOGGER = LogManager.getLogger(TestFrameEnv.class);
-    private static final Map<String, String> VALUES = new HashMap<>();
-    private static final Map<String, Object> YAML_DATA = loadConfigurationFile();
+    private static final TestEnvironmentVariables ENV_VARIABLES = new TestEnvironmentVariables();
 
-    private static final String CONFIG_FILE_PATH_ENV = "ENV_FILE";
     private static final String CLIENT_TYPE_ENV = "CLIENT_TYPE";
     private static final String TOKEN_ENV = "KUBE_TOKEN";
     private static final String URL_ENV = "KUBE_URL";
@@ -39,72 +24,25 @@ public final class TestFrameEnv {
     /**
      * The type of client.
      */
-    public static final String CLIENT_TYPE = getOrDefault(CLIENT_TYPE_ENV, TestFrameConstants.KUBERNETES_CLIENT);
+    public static final String CLIENT_TYPE =
+        ENV_VARIABLES.getOrDefault(CLIENT_TYPE_ENV, TestFrameConstants.KUBERNETES_CLIENT);
 
 
     /**
      * The token for accessing the Kubernetes cluster.
      */
-    public static final String KUBE_TOKEN = getOrDefault(TOKEN_ENV, null);
+    public static final String KUBE_TOKEN = ENV_VARIABLES.getOrDefault(TOKEN_ENV, null);
 
     /**
      * The URL for accessing the Kubernetes cluster.
      */
-    public static final String KUBE_URL = getOrDefault(URL_ENV, null);
+    public static final String KUBE_URL = ENV_VARIABLES.getOrDefault(URL_ENV, null);
 
     private TestFrameEnv() {
         // Private constructor to prevent instantiation
     }
 
     static {
-        String debugFormat = "{}: {}";
-        LoggerUtils.logSeparator("-", 30);
-        LOGGER.info("Used environment variables:");
-        VALUES.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .forEach(entry -> {
-                    if (!Objects.equals(entry.getValue(), "null")) {
-                        LOGGER.info(debugFormat, entry.getKey(), entry.getValue());
-                    }
-                });
-        LoggerUtils.logSeparator("-", 30);
-    }
-
-    /**
-     * Print method.
-     */
-    public static void print() {
-        // Method implementation
-    }
-
-    private static String getOrDefault(String varName, String defaultValue) {
-        return getOrDefault(varName, String::toString, defaultValue);
-    }
-
-    private static <T> T getOrDefault(String var, Function<String, T> converter, T defaultValue) {
-        String value = System.getenv(var) != null ?
-                System.getenv(var) :
-                (Objects.requireNonNull(YAML_DATA).get(var) != null ?
-                        YAML_DATA.get(var).toString() :
-                        null);
-        T returnValue = defaultValue;
-        if (value != null) {
-            returnValue = converter.apply(value);
-        }
-        VALUES.put(var, String.valueOf(returnValue));
-        return returnValue;
-    }
-
-    private static Map<String, Object> loadConfigurationFile() {
-        String config = System.getenv().getOrDefault(CONFIG_FILE_PATH_ENV,
-                Paths.get(System.getProperty("user.dir"), "config.yaml").toAbsolutePath().toString());
-        Yaml yaml = new Yaml();
-        try {
-            File yamlFile = new File(config).getAbsoluteFile();
-            return yaml.load(new FileInputStream(yamlFile));
-        } catch (IOException ex) {
-            LOGGER.info("Yaml configuration not provided or does not exist");
-            return Collections.emptyMap();
-        }
+        ENV_VARIABLES.logEnvironmentVariables();
     }
 }

--- a/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
@@ -5,8 +5,8 @@
 package io.skodjob.testframe.environment;
 
 import io.skodjob.testframe.LoggerUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
@@ -24,9 +24,9 @@ import java.util.function.Function;
  */
 public class TestEnvironmentVariables {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TestEnvironmentVariables.class);
+    private static final Logger LOGGER = LogManager.getLogger(TestEnvironmentVariables.class);
 
-    /* test */ private Map<String, String> envMap;
+    /* test */ private final Map<String, String> envMap;
     private Map<String, String> values = new HashMap<>();
     private Map<String, Object> yamlData = new HashMap<>();
     private final String configFilePath;

--- a/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe.environment;
+
+import io.skodjob.testframe.LoggerUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Class representing environment variables used in the test suite
+ */
+public class TestEnvironmentVariables {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestEnvironmentVariables.class);
+
+    /* test */ private Map<String, String> envMap;
+    private Map<String, String> values = new HashMap<>();
+    private Map<String, Object> yamlData = new HashMap<>();
+    private final String configFilePath;
+    private final String configFilePathEnv = "ENV_FILE";
+
+    /**
+     * {@link TestEnvironmentVariables} object initialization, where the config file is loaded to {@link #yamlData}
+     * if possible.
+     */
+    public TestEnvironmentVariables() {
+        this(System.getenv());
+    }
+
+    /**
+     * {@link TestEnvironmentVariables} object initialization, where the config file is loaded to {@link #yamlData}
+     * if possible.
+     *
+     * @param envMap    Map containing the environment variables. Used mainly for testing purposes.
+     */
+    public TestEnvironmentVariables(Map<String, String> envMap) {
+        this.envMap = envMap;
+        this.configFilePath = envMap.getOrDefault(configFilePathEnv,
+            Paths.get(System.getProperty("user.dir"), "config.yaml").toAbsolutePath().toString());
+        this.yamlData = loadConfigurationFile();
+    }
+
+    /**
+     * Method which returns the value from env variable or its default in String.
+     *
+     * @param envVarName        environment variable name
+     * @param defaultValue      default value, which should be used if the env var is empty and the config file
+     *                          doesn't contain it
+     *
+     * @return  value from env var/config file or default
+     */
+    public String getOrDefault(String envVarName, String defaultValue) {
+        return getOrDefault(envVarName, String::toString, defaultValue);
+    }
+
+    /**
+     * Method which returns the value from env variable or its default in the specified type.
+     * It also checks if the env var is specified in the configuration file before applying the default.
+     *
+     * @param envVarName        environment variable name
+     * @param converter         converter to the desired type
+     * @param defaultValue      default value, which should be used if the env var is empty and the config file
+     *                          doesn't contain it
+     *
+     * @return  value from env var/config file or default
+     * @param <T>   desired type
+     */
+    public <T> T getOrDefault(String envVarName, Function<String, T> converter, T defaultValue) {
+        String value = envMap.get(envVarName) != null ?
+            envMap.get(envVarName) :
+            (Objects.requireNonNull(yamlData).get(envVarName) != null ?
+                yamlData.get(envVarName).toString() :
+                null);
+
+        T returnValue = defaultValue;
+
+        if (value != null) {
+            returnValue = converter.apply(value);
+        }
+
+        values.put(envVarName, String.valueOf(returnValue));
+        return returnValue;
+    }
+
+    /**
+     * Method that loads configuration file - either from specified path by {@link #configFilePathEnv} or from
+     * the default path (in the `config.yaml` file on the `user.dir` path).
+     * If the file doesn't exist, the info log is printed and empty Map is returned.
+     *
+     * @return  Map with env variables and their values, or empty Map in case of not existing file
+     */
+    protected Map<String, Object> loadConfigurationFile() {
+        Yaml yaml = new Yaml();
+
+        try {
+            File yamlFile = new File(configFilePath).getAbsoluteFile();
+            return yaml.load(new FileInputStream(yamlFile));
+        } catch (IOException ex) {
+            LOGGER.info("Yaml configuration not provided or does not exist");
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Method which logs environment variables parsed by {@link TestEnvironmentVariables}
+     */
+    public void logEnvironmentVariables() {
+        String debugFormat = "{}: {}";
+
+        LoggerUtils.logSeparator("-", 30);
+
+        LOGGER.info("Used environment variables:");
+
+        values.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEach(entry -> {
+                if (!Objects.equals(entry.getValue(), "null")) {
+                    LOGGER.info(debugFormat, entry.getKey(), entry.getValue());
+                }
+            });
+
+        LoggerUtils.logSeparator("-", 30);
+    }
+}

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/TestEnvironmentVariablesTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/TestEnvironmentVariablesTest.java
@@ -1,0 +1,32 @@
+package io.skodjob.testframe.clients;
+
+import io.skodjob.testframe.environment.TestEnvironmentVariables;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestEnvironmentVariablesTest {
+
+    @Test
+    void testGetEnvVariablesCorrectly() {
+        assertEquals(MyEnvs.MY_ENV, "this");
+        assertEquals(MyEnvs.SECOND_ENV, "23");
+    }
+
+    public static class MyEnvs {
+        private static final Map<String, String> ENVS_MAP = Map.of(
+            "MY_ENV", "this",
+            "THIRD_ENV", "that"
+        );
+
+        public static final TestEnvironmentVariables ENVIRONMENT_VARIABLES = new TestEnvironmentVariables(ENVS_MAP);
+        public static final String MY_ENV = ENVIRONMENT_VARIABLES.getOrDefault("MY_ENV", "");
+        public static final String SECOND_ENV = ENVIRONMENT_VARIABLES.getOrDefault("SECOND_ENV", "23");
+
+        static {
+            ENVIRONMENT_VARIABLES.logEnvironmentVariables();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `TestEnvironmentVariables` object, which contains more or less everything from the `TestFrameEnv`.
Thanks to this, we are able to initialize this object in each test suite, print the env variables and extend the class if needed.

**Why I created the object instead of making the functions public in the TestFrameEnv**

The print is done when the `TestFrameEnv` is initialized. That's usually done before the class which can extend this one is called/initialized. So the log of the env variables doesn't show the full list + it will be quite confusing to print the same values more times -> when the `TestFrameEnv` is initialized and then when our class (so even if I add a print method there, it will show some values twice)