### PR TITLE
Implement LogCollector

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,15 @@ These clients are initialized and connected to the test cluster based on the con
 For better clarity regarding the test logs, `TestFrame` library provides ASCII vial separation of tests and test classes.
 
 ### Metrics Collector
-The [`MetricsCollector`](test-frame-metrics-collector/MetricsCollector.md) is designed to facilitate the collection of metrics from Kubernetes pods. 
+The `MetricsCollector` is designed to facilitate the collection of metrics from Kubernetes pods. 
 It integrates seamlessly with Kubernetes environments to gather and process metrics data efficiently. 
 For more detailed documentation, see the MetricsCollector [README](test-frame-metrics-collector/README.md).
+
+### Log Collector
+`LogCollector` is utility for collecting logs from the Pods (and their containers), descriptions of Pods, and YAML
+descriptions of resources specified by users, collected from the desired Namespaces.
+To Log Collector's [README](test-frame-log-collector/README.md) contains detailed documentation about this component,
+together with the usage and installation.
 
 ### Utils
 `TestFrame` contains also tweaks and utils for better working with kubernetes cluster.

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,8 @@
         <jackson-dataformat-yaml.version>2.17.1</jackson-dataformat-yaml.version>
 
         <it.skip>true</it.skip>
-        <ut.skip>false</ut.skip>
+        <!--suppress UnresolvedMavenProperty -->
+        <ut.skip>${skipTests}</ut.skip>
 
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
     </properties>
@@ -114,6 +115,11 @@
             <dependency>
                 <groupId>io.skodjob</groupId>
                 <artifactId>test-frame-kubernetes</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.skodjob</groupId>
+                <artifactId>test-frame-log-collector</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -343,7 +349,7 @@
                 <module>test-frame-common</module>
                 <module>test-frame-kubernetes</module>
                 <module>test-frame-openshift</module>
-                <module>test-frame-test</module>
+                <module>test-frame-test-examples</module>
                 <module>test-frame-metrics-collector</module>
                 <module>test-frame-log-collector</module>
             </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
 
         <fabric8.version>6.13.0</fabric8.version>
         <log4j.version>2.17.2</log4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
+
+        <!--  TEST dependencies  -->
+        <mockito.version>5.11.0</mockito.version>
+        <apache.commons.version>2.16.1</apache.commons.version>
 
         <!--   Build tools' properties     -->
         <spotbugs.version>4.7.3</spotbugs.version>
@@ -92,6 +97,9 @@
         <junit.platform.version>1.10.2</junit.platform.version>
         <maven.surefire.version>3.2.2</maven.surefire.version>
         <jackson-dataformat-yaml.version>2.17.1</jackson-dataformat-yaml.version>
+
+        <it.skip>true</it.skip>
+        <ut.skip>false</ut.skip>
 
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
     </properties>
@@ -170,6 +178,29 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${apache.commons.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -258,10 +289,65 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>verify</goal>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipITs>${it.skip}</skipITs>
+                    <forkCount>1</forkCount>
+                    <includes>
+                        <include>**/IT*.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
+                    <properties>
+                        <configurationParameters>
+                            junit.jupiter.extensions.autodetection.enabled = true
+                        </configurationParameters>
+                    </properties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <properties>
+                        <configurationParameters>
+                            junit.jupiter.extensions.autodetection.enabled = true
+                        </configurationParameters>
+                    </properties>
+                    <skipTests>${ut.skip}</skipTests>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
+        <profile>
+            <id>integration</id>
+            <properties>
+                <it.skip>false</it.skip>
+                <ut.skip>true</ut.skip>
+            </properties>
+            <modules>
+                <module>test-frame-common</module>
+                <module>test-frame-kubernetes</module>
+                <module>test-frame-openshift</module>
+                <module>test-frame-test</module>
+                <module>test-frame-metrics-collector</module>
+                <module>test-frame-log-collector</module>
+            </modules>
+        </profile>
         <profile>
             <id>default</id>
             <activation>
@@ -273,6 +359,7 @@
                 <module>test-frame-openshift</module>
                 <module>test-frame-test-examples</module>
                 <module>test-frame-metrics-collector</module>
+                <module>test-frame-log-collector</module>
             </modules>
         </profile>
         <profile>
@@ -285,6 +372,7 @@
                 <module>test-frame-kubernetes</module>
                 <module>test-frame-openshift</module>
                 <module>test-frame-metrics-collector</module>
+                <module>test-frame-log-collector</module>
             </modules>
             <properties>
                 <!--suppress UnresolvedMavenProperty -->
@@ -347,6 +435,7 @@
                                         <descriptor>test-frame-kubernetes/src/main/assembly/dist.xml</descriptor>
                                         <descriptor>test-frame-openshift/src/main/assembly/dist.xml</descriptor>
                                         <descriptor>test-frame-metrics-collector/src/main/assembly/dist.xml</descriptor>
+                                        <descriptor>test-frame-log-collector/src/main/assembly/dist.xml</descriptor>
                                     </descriptors>
                                 </configuration>
                             </execution>

--- a/test-frame-common/pom.xml
+++ b/test-frame-common/pom.xml
@@ -108,25 +108,4 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.version}</version>
-                <configuration>
-                    <test>io.skodjob.testframe.**</test>
-                    <properties>
-                        <configurationParameters>
-                            junit.jupiter.extensions.autodetection.enabled = true
-                        </configurationParameters>
-                    </properties>
-                    <environmentVariables>
-                        <TEST_LOG_LEVEL>DEBUG</TEST_LOG_LEVEL>
-                    </environmentVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/test-frame-log-collector/README.md
+++ b/test-frame-log-collector/README.md
@@ -132,7 +132,7 @@ LogCollector logCollector = new LogCollectorBuilder()
     .build();
 
 public static void collectFromNamespaces() {
-    logCollector.collectFromNamespaceWithLabels(new LabelSelectorBuilder()
+    logCollector.collectFromNamespacesWithLabels(new LabelSelectorBuilder()
         .withMatchLabels(Map.of("my-label", "my-value"))
     );
 }
@@ -140,22 +140,23 @@ public static void collectFromNamespaces() {
 
 The tree path will look similarly to above examples, there will be folders for Namespaces matching the specified labels.
 
-### Changing the root folder path
+### Specifying additional folder path
 
-In case that you would like to change the root path, there is a method for that in the `LogCollector` object itself:
+In case that you would like to collect the logs to additional sub-directories of your root folder, the `LogCollector` contains
+methods for specifying the additional path for each of the three methods for log collection (mentioned above):
 
-```java
-import io.skodjob.testframe.LogCollector;
-import io.skodjob.testframe.LogCollectorBuilder;
-import org.junit.jupiter.api.AfterEach;
+- `collectFromNamespacesWithLabelsToFolder(LabelSelector labelSelector, String folderPath)`
+- `collectFromNamespacesToFolder(List<String> namespacesNames, String folderPath)`
+- `collectFromNamespaceToFolder(String namespaceName, String folderPath)`
 
-LogCollector logCollector = new LogCollectorBuilder()
-    .withResources("secret", "deployment", "my-custom-resource")
-    .withRootFolderPath("/path/to/logs/folder")
-    .build();
+The usage is same as for the methods that don't contain the `folderPath` parameter.
+The `folderPath` is appended after the `rootPath` you specified during the `LogCollector` initialization.
 
-@AfterEach
-void changeRootPath() {
-    logCollector.changeRootFolderPath("/path/to/another/folder");
-}
+Example:
+```
+rootPath: /tmp/logs
+folderPath: run1
+namespaceName: my-namespace
+
+final full path for log collection: /tmp/logs/run1/my-namespace/
 ```

--- a/test-frame-log-collector/pom.xml
+++ b/test-frame-log-collector/pom.xml
@@ -3,14 +3,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>io.skodjob</groupId>
         <artifactId>test-frame</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>test-frame-metrics-collector</artifactId>
+    <artifactId>test-frame-log-collector</artifactId>
 
     <licenses>
         <license>
@@ -73,10 +72,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-common</artifactId>
         </dependency>
-
+        <!-- Logger -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
@@ -89,7 +92,10 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -103,6 +109,11 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/test-frame-log-collector/pom.xml
+++ b/test-frame-log-collector/pom.xml
@@ -67,6 +67,8 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/test-frame-log-collector/src/main/assembly/dist.xml
+++ b/test-frame-log-collector/src/main/assembly/dist.xml
@@ -1,0 +1,35 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>zip</id>
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <formats>
+        <format>tar.gz</format>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <includes>
+                <include>README*</include>
+            </includes>
+            <fileMode>0644</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <includes>
+                <include>LICENSE</include>
+            </includes>
+            <fileMode>0644</fileMode>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <scope>runtime</scope>
+            <outputDirectory>libs</outputDirectory>
+            <fileMode>0644</fileMode>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/CollectorConstants.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/CollectorConstants.java
@@ -13,6 +13,10 @@ public interface CollectorConstants {
      */
     String POD = "pod";
     /**
+     * Pod resource type - plural
+     */
+    String PODS = "pods";
+    /**
      * Container resource type
      */
     String CONTAINER = "container";

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/CollectorConstants.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/CollectorConstants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe;
+
+/**
+ * Class containing constants used in {@link LogCollector}
+ */
+public interface CollectorConstants {
+    /**
+     * Pod resource type
+     */
+    String POD = "pod";
+    /**
+     * Container resource type
+     */
+    String CONTAINER = "container";
+    /**
+     * Events resource type
+     */
+    String EVENTS = "events";
+    /**
+     * Prefix for logs files
+     */
+    String LOGS = "logs";
+    /**
+     * Prefix for description files
+     */
+    String DESCRIBE = "describe";
+}

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollector.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollector.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.skodjob.testframe.clients.KubeClient;
+import io.skodjob.testframe.clients.cmdClient.KubeCmdClient;
+import io.skodjob.testframe.clients.cmdClient.Kubectl;
+import io.skodjob.testframe.resources.KubeResourceManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * LogCollector class containing all methods used for logs and YAML collection.
+ */
+public class LogCollector {
+    private static final Logger LOGGER = LogManager.getLogger(KubeResourceManager.class);
+    protected final List<String> resources;
+    protected String rootFolderPath;
+    private KubeCmdClient<Kubectl> kubeCmdClient = new Kubectl();
+    private KubeClient kubeClient = new KubeClient();
+
+    /**
+     * Constructor of the {@link LogCollector}, which uses parameters from {@link LogCollectorBuilder}
+     *
+     * @param builder   {@link LogCollectorBuilder} with configuration for {@link LogCollector}
+     */
+    public LogCollector(LogCollectorBuilder builder) {
+        this.resources = builder.getResources() == null ? Collections.emptyList() : builder.getResources();
+        this.rootFolderPath = builder.getRootFolderPath();
+    }
+
+    /**
+     * Sets {@link KubeClient} for the LogCollector.
+     * Mainly for testing purposes (to mock the client).
+     *
+     * @param kubeClient     {@link KubeClient} - usually mocked.
+     */
+    /* test */ public void setKubeClient(KubeClient kubeClient) {
+        this.kubeClient = kubeClient;
+    }
+
+    /**
+     * Sets {@link KubeCmdClient} for the LogCollector.
+     * Mainly for testing purposes (to mock the client).
+     *
+     * @param kubeCmdClient     {@link KubeCmdClient} - usually mocked.
+     */
+    /* test */ public void setKubeCmdClient(KubeCmdClient<Kubectl> kubeCmdClient) {
+        this.kubeCmdClient = kubeCmdClient;
+    }
+
+    /**
+     * Changes root folder path where the logs should be collected into.
+     *
+     * @param rootFolderPath    path to the folder, where the logs should be collected into
+     */
+    public void changeRootFolderPath(String rootFolderPath) {
+        this.rootFolderPath = rootFolderPath;
+    }
+
+    /**
+     * Method that collects all logs and YAML files from Namespaces containing specified LabelSelector
+     *
+     * @param labelSelector     LabelSelector containing Labels that Namespace should contain
+     */
+    public void collectFromNamespaceWithLabels(LabelSelector labelSelector) {
+        List<String> namespacesWithLabel = kubeClient.getClient()
+            .namespaces()
+            .withLabelSelector(labelSelector)
+            .list()
+            .getItems()
+            .stream()
+            .map(namespace -> namespace.getMetadata().getName())
+            .toList();
+
+        namespacesWithLabel.forEach(this::collectFromNamespace);
+    }
+
+    /**
+     * Method that collects all logs and YAML files from specified set of Namespaces
+     *
+     * @param namespacesNames   set of Namespace from which the logs should be collected
+     */
+    public void collectFromNamespaces(String... namespacesNames) {
+        Arrays.stream(namespacesNames).forEach(this::collectFromNamespace);
+    }
+
+    /**
+     * Method that collects all logs and YAML files from specified Namespace
+     *
+     * @param namespaceName     name of Namespace from which the logs should be collected
+     */
+    public void collectFromNamespace(String namespaceName) {
+        // check if Namespace exists
+        if (kubeClient.getClient().namespaces().withName(namespaceName).get() != null) {
+            String namespaceFolderPath = createNamespaceDirectory(namespaceName);
+
+            collectLogsFromPodsInNamespace(namespaceName);
+            collectEventsFromNamespace(namespaceFolderPath, namespaceName);
+
+            collectResourcesDescInNamespace(namespaceName);
+        } else {
+            LOGGER.warn("Specified Namespace: {} doesn't exist", namespaceName);
+        }
+    }
+
+    /**
+     * Method for collecting logs from all Pods (and their containers) in specified Namespace.
+     * At the start, it creates a folder in the Namespace dir for the `pod` resource.
+     * After that it lists all Pods in the Namespace and collects names of all Containers and InitContainers.
+     * Then, for each Pod-(Init)Container it collects logs and then creates a log file, where are the logs stored.
+     * Additionally, it stores description of each Pod in the Namespace.
+     *
+     * @param namespaceName     name of Namespace from which the logs (and Pod descriptions) should be collected
+     */
+    public void collectLogsFromPodsInNamespace(String namespaceName) {
+        LOGGER.info("Collecting logs from all Pods in Namespace: {}", namespaceName);
+        List<Pod> pods = kubeClient.listPods(namespaceName);
+
+        if (!pods.isEmpty()) {
+            String podsFolderPath = createResourceDirectoryInNamespaceDir(namespaceName, CollectorConstants.POD);
+
+            pods.forEach(pod -> {
+                String podName = pod.getMetadata().getName();
+
+                List<String> containers = pod.getSpec().getContainers().stream().map(Container::getName).toList();
+                List<String> initContainers = pod.getSpec().getInitContainers().stream()
+                    .map(Container::getName).toList();
+
+                collectPodDescription(podsFolderPath, namespaceName, podName);
+                collectLogsFromPodContainers(podsFolderPath, namespaceName, podName, containers);
+                collectLogsFromPodContainers(podsFolderPath, namespaceName, podName, initContainers);
+            });
+        }
+    }
+
+    /**
+     * Method that for each container collects the log using
+     * {@link #collectLogsFromPodContainer(String, String, String, String)}
+     *
+     * @param podsFolderPath    path to the "pod" folder (for example: /tmp/logs/namespace/pods)
+     * @param namespaceName     name of Namespace where the Pod is present
+     * @param podName           name of Pod from which the log should be collected
+     * @param containerNames    list of container names from which the log should be collected
+     */
+    private void collectLogsFromPodContainers(
+        String podsFolderPath,
+        String namespaceName,
+        String podName,
+        List<String> containerNames
+    ) {
+        containerNames.forEach(containerName ->
+            collectLogsFromPodContainer(podsFolderPath, namespaceName, podName, containerName));
+    }
+
+    /**
+     * Method that collects log from specified Pod and Container
+     *
+     * @param podsFolderPath    path to the "pod" folder (for example: /tmp/logs/namespace/pods)
+     * @param namespaceName     name of Namespace where the Pod is present
+     * @param podName           name of Pod from which the log should be collected
+     * @param containerName     name of container from which the log should be collected
+     */
+    private void collectLogsFromPodContainer(
+        String podsFolderPath,
+        String namespaceName,
+        String podName,
+        String containerName
+    ) {
+        String containerLog = kubeCmdClient.inNamespace(namespaceName).logs(podName, containerName);
+        String podConLogFileName = LogCollectorUtils.getLogFileNameForPodContainer(podName, containerName);
+        String filePath = LogCollectorUtils.getFullPathForFolderPathAndFileName(podsFolderPath, podConLogFileName);
+
+        writeDataToFile(filePath, containerLog);
+    }
+
+    /**
+     * Method that collects description of specified Pod
+     *
+     * @param podsFolderPath    path to the "pod" folder (for example: /tmp/logs/namespace/pods)
+     * @param namespaceName     name of Namespace where the Pod is present
+     * @param podName           name of Pod from which the description should be collected
+     */
+    private void collectPodDescription(String podsFolderPath, String namespaceName, String podName) {
+        String podDesc = kubeCmdClient.inNamespace(namespaceName).describe(CollectorConstants.POD, podName);
+        String podDescFileName = LogCollectorUtils.getLogFileNameForPodDescription(podName);
+        String filePath = LogCollectorUtils.getFullPathForFolderPathAndFileName(podsFolderPath, podDescFileName);
+
+        writeDataToFile(filePath, podDesc);
+    }
+
+    /**
+     * Method that collects all Events (kubectl get events) from Namespace
+     *
+     * @param namespaceFolderPath   path to the Namespace folder (for example: /tmp/logs/namespace)
+     * @param namespaceName         name of Namespace from which the events should be collected
+     */
+    public void collectEventsFromNamespace(String namespaceFolderPath, String namespaceName) {
+        LOGGER.info("Collecting events from Namespace: {}", namespaceName);
+        String events = kubeCmdClient.inNamespace(namespaceName).getEvents();
+        String eventsFileName = LogCollectorUtils.getLogFileNameForResource(CollectorConstants.EVENTS);
+        String fileName = LogCollectorUtils.getFullPathForFolderPathAndFileName(namespaceFolderPath, eventsFileName);
+
+        writeDataToFile(fileName, events);
+    }
+
+    /**
+     * Method that collects YAML descriptions of specified resources (resource types)
+     * and stores them in particular folders and their YAML files.
+     *
+     * @param namespaceName     name of Namespace from where the YAMLs should be collected
+     */
+    private void collectResourcesDescInNamespace(String namespaceName) {
+        resources.forEach(resource -> collectDescriptionOfResourceInNamespace(namespaceName, resource));
+    }
+
+
+    /**
+     * Method that collects YAML descriptions for specified resource type (for example secret, configmap, ...).
+     * It firstly lists that, in specified Namespace, there are resources with that type.
+     * When the resources exist in Namespace, the folder for the resource type is created.
+     * Finally, for each resource the YAML description is collected and stored in YAML file inside the type's folder.
+     *
+     * @param namespaceName     name of Namespace from where the YAMLs should be collected
+     * @param resourceType      name of the resource type (for example secret, configmap, ...)
+     */
+    private void collectDescriptionOfResourceInNamespace(String namespaceName, String resourceType) {
+        LOGGER.info("Collecting YAMLs of {} from Namespace: {}", resourceType, namespaceName);
+        List<String> resources = kubeCmdClient.inNamespace(namespaceName).list(resourceType);
+
+        if (resources != null && !resources.isEmpty()) {
+            String fullFolderPath = createResourceDirectoryInNamespaceDir(namespaceName, resourceType);
+
+            resources.forEach(resourceName -> {
+                String yaml = kubeCmdClient.inNamespace(namespaceName).getResourceAsYaml(resourceType, resourceName);
+
+                String resFileName = LogCollectorUtils.getYamlFileNameForResource(resourceName);
+                String fileName = LogCollectorUtils.getFullPathForFolderPathAndFileName(fullFolderPath, resFileName);
+                writeDataToFile(fileName, yaml);
+            });
+        }
+    }
+
+    /**
+     * Method that creates directory for specified Namespace in the {@link #rootFolderPath}
+     *
+     * @param namespaceName     name of Namespace for which the folder will be created
+     *
+     * @return  full path to the Namespace directory
+     */
+    private String createNamespaceDirectory(String namespaceName) {
+        return createLogDirOnPath(LogCollectorUtils.getFullDirPathWithNamespace(rootFolderPath, namespaceName));
+    }
+
+    /**
+     * Method that creates directory for specified resource type in the Namespace directory
+     *
+     * @param namespaceName     name of Namespace directory where the directory for the resource type will be created
+     * @param resourceType      name of resource type for which the directory will be created
+     *
+     * @return  full path to the resource type's directory
+     */
+    private String createResourceDirectoryInNamespaceDir(String namespaceName, String resourceType) {
+        return createLogDirOnPath(
+            LogCollectorUtils.getFullDirPathWithNamespaceAndForResourceType(
+                rootFolderPath,
+                namespaceName,
+                resourceType
+            )
+        );
+    }
+
+    /**
+     * Method that creates directory in path.
+     * It firstly checks if the directory exists or not and if not, it creates all the directories that are missing.
+     *
+     * @param fullPathToDirectory   full path to the desired directory
+     *
+     * @return  path to newly created directory
+     */
+    private String createLogDirOnPath(String fullPathToDirectory) {
+        File logDir = Paths.get(fullPathToDirectory).toFile();
+
+        if (!logDir.exists()) {
+            if (!logDir.mkdirs()) {
+                throw new RuntimeException(
+                    String.format("Failed to create root log directories on path: %s", logDir.getAbsolutePath())
+                );
+            }
+        }
+
+        return logDir.getAbsolutePath();
+    }
+
+    /**
+     * Method that writes data to file (on path, specified by {@param fullFilePath}.
+     *
+     * @param fullFilePath  full path to file (for example: /tmp/logs/my-namespace/secret.yaml)
+     * @param data          data which should be written to file
+     */
+    private void writeDataToFile(String fullFilePath, String data) {
+        if (data != null && !data.isEmpty()) {
+            try {
+                Files.writeString(Paths.get(fullFilePath), data, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new RuntimeException(
+                    String.format("Failed to write to the %s file due to: %s", fullFilePath, e.getMessage())
+                );
+            }
+        }
+    }
+}

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollector.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollector.java
@@ -40,6 +40,11 @@ public class LogCollector {
      */
     public LogCollector(LogCollectorBuilder builder) {
         this.resources = builder.getResources() == null ? Collections.emptyList() : builder.getResources();
+
+        if (builder.getRootFolderPath() == null) {
+            throw new RuntimeException("rootFolderPath should be filled, but it's empty");
+        }
+
         this.rootFolderPath = builder.getRootFolderPath();
     }
 

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollectorBuilder.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollectorBuilder.java
@@ -6,6 +6,7 @@ package io.skodjob.testframe;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Builder class for the {@link LogCollector}
@@ -53,7 +54,11 @@ public class LogCollectorBuilder {
      * @return  {@link LogCollectorBuilder} object
      */
     public LogCollectorBuilder withResources(String... resources) {
-        this.resources = Arrays.stream(resources).toList();
+        this.resources = Arrays.stream(resources).toList()
+            .stream()
+            .filter(resource -> !resource.equals(CollectorConstants.POD) && !resource.equals(CollectorConstants.PODS))
+            .collect(Collectors.toList());
+
         return this;
     }
 

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollectorBuilder.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollectorBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Builder class for the {@link LogCollector}
+ */
+public class LogCollectorBuilder {
+
+    private String rootFolderPath;
+    private List<String> resources;
+
+    /**
+     * Constructor for creating {@link LogCollectorBuilder} with parameters from
+     * current instance of {@link LogCollector}.
+     *
+     * @param logCollector  current instance of {@link LogCollector}
+     */
+    public LogCollectorBuilder(LogCollector logCollector) {
+        this.rootFolderPath = logCollector.rootFolderPath;
+        this.resources = logCollector.resources;
+    }
+
+    /**
+     * Empty constructor, we can use the "with" methods to build the LogCollector's configuration
+     */
+    public LogCollectorBuilder() {
+        // empty constructor
+    }
+
+    /**
+     * Method for setting the rootFolderPath, where the logs collection will happen
+     *
+     * @param rootFolderPath    folder path for the root folder, where the logs should be collected into
+     *
+     * @return  {@link LogCollectorBuilder} object
+     */
+    public LogCollectorBuilder withRootFolderPath(String rootFolderPath) {
+        this.rootFolderPath = rootFolderPath;
+        return this;
+    }
+
+    /**
+     * Method for setting the resources, which YAML descriptions should be collected as part of the log collection
+     *
+     * @param resources    array of resources
+     *
+     * @return  {@link LogCollectorBuilder} object
+     */
+    public LogCollectorBuilder withResources(String... resources) {
+        this.resources = Arrays.stream(resources).toList();
+        return this;
+    }
+
+    /**
+     * Getter returning currently configured {@link #rootFolderPath}
+     *
+     * @return {@link #rootFolderPath}
+     */
+    public String getRootFolderPath() {
+        return this.rootFolderPath;
+    }
+
+    /**
+     * Getter returning currently configured {@link #resources} in {@link List} object
+     *
+     * @return {@link #resources}
+     */
+    public List<String> getResources() {
+        return this.resources;
+    }
+
+    /**
+     * Method for building the {@link LogCollector} object
+     *
+     * @return {@link LogCollector} configured by the specified parameters
+     */
+    public LogCollector build() {
+        return new LogCollector(this);
+    }
+}

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollectorUtils.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollectorUtils.java
@@ -86,36 +86,31 @@ public class LogCollectorUtils {
     /**
      * Method returning full path from {@param rootFolderPath} to the {@param namespaceName} dir
      *
-     * @param rootFolderPath    root folder path where the sub-dirs will be created into
+     * @param folderPath        root folder path where the sub-dirs will be created into
      * @param namespaceName     name of the Namespace for which the folder will be created
      *
      * @return  full path from {@param rootFolderPath} to the {@param namespaceName} dir
      */
-    public static String getFullDirPathWithNamespace(String rootFolderPath, String namespaceName) {
-        return String.join("/", rootFolderPath, namespaceName);
+    public static String getFullDirPathWithNamespace(String folderPath, String namespaceName) {
+        return String.join("/", folderPath, namespaceName);
     }
 
     /**
-     * Method returning full path from {@param rootFolderPath} through the {@param namespaceName} dir
-     * to the {@param resourceType} dir.
+     * Method returning full path from {@param namespaceFolderPath} to the {@param resourceType} dir.
      * Example: /tmp/logs/my-namespace/secret
      *
-     * @param rootFolderPath    root folder path where the sub-dirs will be created into
-     * @param namespaceName     name of the Namespace (and its directory) where the folder
-     *                          for desired resource will be created
-     * @param resourceType      type of resource for which the folder will be created
+     * @param namespaceFolderPath   Namespace folder path where the sub-dirs will be created into
+     * @param resourceType          type of resource for which the folder will be created
      *
-     * @return  full path from {@param rootFolderPath} through the {@param namespaceName} dir
-     * to the {@param resourceType} dir
+     * @return  full path from {@param namespaceFolderPath} to the {@param resourceType} dir
      */
-    public static String getFullDirPathWithNamespaceAndForResourceType(
-        String rootFolderPath,
-        String namespaceName,
+    public static String getNamespaceFullDirPathForResourceType(
+        String namespaceFolderPath,
         String resourceType
     ) {
         return String.join(
             "/",
-            getFullDirPathWithNamespace(rootFolderPath, namespaceName),
+            namespaceFolderPath,
             resourceType.toLowerCase(Locale.ROOT)
         );
     }
@@ -131,5 +126,22 @@ public class LogCollectorUtils {
      */
     public static String getFullPathForFolderPathAndFileName(String folderPath, String fileName) {
         return String.join("/", folderPath, fileName);
+    }
+
+    /**
+     * Method returning full path from specified {@param rootPath} into the {@param folderPath}.
+     * This is used in cases that we have root path specified in LogCollector, but for the new log collection, we
+     * want to collect everything in different sub-dirs (and the Namespace sub-dirs are not enough).
+     *
+     * @param rootPath      root path specified in LogCollector during the instance initialization
+     * @param folderPath    additional folder path
+     * @return  full path from  {@param rootPath} into the {@param folderPath}
+     */
+    public static String getFolderPath(String rootPath, String folderPath) {
+        if (folderPath == null) {
+            return rootPath;
+        }
+
+        return String.join("/", rootPath, folderPath);
     }
 }

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollectorUtils.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollectorUtils.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe;
+
+import java.util.Locale;
+
+/**
+ * Helper class containing methods used in {@link LogCollector}
+ */
+public class LogCollectorUtils {
+    // YAML type of file
+    private static final String YAML_TYPE = "yaml";
+    // log type of file
+    private static final String LOG_TYPE = "log";
+
+    private LogCollectorUtils() {
+        // Private constructor to prevent instantiation
+    }
+
+    /**
+     * Method returning name of the YAML file for particular resource
+     *
+     * @param resourceName  name of the resource
+     *
+     * @return  name of the YAML file for particular resource
+     */
+    public static String getYamlFileNameForResource(String resourceName) {
+        return getFileNameForResourceAndType(resourceName, YAML_TYPE);
+    }
+
+    /**
+     * Method returning name of the log file for particular resource
+     *
+     * @param resourceName  name of the resource
+     *
+     * @return  name of the log file for particular resource
+     */
+    public static String getLogFileNameForResource(String resourceName) {
+        return getFileNameForResourceAndType(resourceName, LOG_TYPE);
+    }
+
+    /**
+     * Method returning name of the log file for Pod and its container
+     *
+     * @param podName  name of the Pod
+     * @param containerName  name of the Container
+     *
+     * @return  name of the log file for Pod and its container
+     */
+    public static String getLogFileNameForPodContainer(String podName, String containerName) {
+        return getFileNameForResourceAndType(
+            String.join("-", CollectorConstants.LOGS, CollectorConstants.POD,
+                podName, CollectorConstants.CONTAINER, containerName),
+            LOG_TYPE
+        );
+    }
+
+    /**
+     * Method returning name of the log file for Pod (and its description)
+     *
+     * @param podName  name of the Pod
+     *
+     * @return  name of the log file for Pod (and its description)
+     */
+    public static String getLogFileNameForPodDescription(String podName) {
+        return getFileNameForResourceAndType(
+            String.join("-", CollectorConstants.DESCRIBE, CollectorConstants.POD, podName),
+            LOG_TYPE
+        );
+    }
+
+    /**
+     * Method returning name of the file with correct file type specified under {@param fileType}
+     *
+     * @param resourceName  name of the resource
+     * @param fileType      type of file (YAML, log)
+     *
+     * @return  name of the file with a specified type and for particular resource
+     */
+    private static String getFileNameForResourceAndType(String resourceName, String fileType) {
+        return String.join(".", resourceName.toLowerCase(Locale.ROOT), fileType);
+    }
+
+    /**
+     * Method returning full path from {@param rootFolderPath} to the {@param namespaceName} dir
+     *
+     * @param rootFolderPath    root folder path where the sub-dirs will be created into
+     * @param namespaceName     name of the Namespace for which the folder will be created
+     *
+     * @return  full path from {@param rootFolderPath} to the {@param namespaceName} dir
+     */
+    public static String getFullDirPathWithNamespace(String rootFolderPath, String namespaceName) {
+        return String.join("/", rootFolderPath, namespaceName);
+    }
+
+    /**
+     * Method returning full path from {@param rootFolderPath} through the {@param namespaceName} dir
+     * to the {@param resourceType} dir.
+     * Example: /tmp/logs/my-namespace/secret
+     *
+     * @param rootFolderPath    root folder path where the sub-dirs will be created into
+     * @param namespaceName     name of the Namespace (and its directory) where the folder
+     *                          for desired resource will be created
+     * @param resourceType      type of resource for which the folder will be created
+     *
+     * @return  full path from {@param rootFolderPath} through the {@param namespaceName} dir
+     * to the {@param resourceType} dir
+     */
+    public static String getFullDirPathWithNamespaceAndForResourceType(
+        String rootFolderPath,
+        String namespaceName,
+        String resourceType
+    ) {
+        return String.join(
+            "/",
+            getFullDirPathWithNamespace(rootFolderPath, namespaceName),
+            resourceType.toLowerCase(Locale.ROOT)
+        );
+    }
+
+    /**
+     * Method returning full path to the file in the logs directory.
+     * Example: /tmp/logs/my-namespace/secret/my-secret.yaml
+     *
+     * @param folderPath    full path where the file should be created
+     * @param fileName      name of the file
+     *
+     * @return  full path to the file in the logs directory
+     */
+    public static String getFullPathForFolderPathAndFileName(String folderPath, String fileName) {
+        return String.join("/", folderPath, fileName);
+    }
+}

--- a/test-frame-log-collector/src/main/resources/log4j2.properties
+++ b/test-frame-log-collector/src/main/resources/log4j2.properties
@@ -1,4 +1,4 @@
-name = TFConfig
+name = LCConfig
 
 appender.console.type = Console
 appender.console.name = STDOUT

--- a/test-frame-log-collector/src/main/resources/log4j2.properties
+++ b/test-frame-log-collector/src/main/resources/log4j2.properties
@@ -1,0 +1,28 @@
+name = TFConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highlight{%-5p} [%c{1}:%L] %m%n
+
+appender.rolling.type = RollingFile
+appender.rolling.name = RollingFile
+appender.rolling.fileName = ${env:TEST_LOG_DIR:-target/logs}/tf-debug-${env:BUILD_ID:-0}.log
+appender.rolling.filePattern = ${env:TEST_LOG_DIR:-target/logs}/tf-debug-%d{yyyy-MM-dd-HH-mm-ss}-%i.log.gz
+appender.rolling.policies.type = Policies
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size=100MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 5
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern=%d{yyyy-MM-dd HH:mm:ss}{GMT} %-5p [%c{1}:%L] %m%n
+
+rootLogger.level = ${env:TEST_ROOT_LOG_LEVEL:-DEBUG}
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.appenderRef.console.level = ${env:TEST_LOG_LEVEL:-INFO}
+rootLogger.appenderRef.rolling.ref = RollingFile
+rootLogger.appenderRef.rolling.level = DEBUG
+rootLogger.additivity = false
+
+logger.fabric8.name = io.fabric8.kubernetes.client
+logger.fabric8.level = OFF

--- a/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorBuilderTest.java
+++ b/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorBuilderTest.java
@@ -1,0 +1,29 @@
+package io.skodjob.testframe;
+
+import io.skodjob.testframe.annotations.TestVisualSeparator;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@TestVisualSeparator
+public class LogCollectorBuilderTest {
+
+    @Test
+    void testPassingPodAndPodsAsResourcesToLogCollectorBuilder() {
+        LogCollectorBuilder logCollectorBuilder = new LogCollectorBuilder()
+            .withResources("pod", "pods");
+
+        assertEquals(Collections.emptyList(), logCollectorBuilder.getResources());
+    }
+
+    @Test
+    void testRuntimeExceptionIsThrownIfRootFolderPathIsNotSpecified() {
+        LogCollectorBuilder logCollectorBuilder = new LogCollectorBuilder();
+
+        assertThrows(RuntimeException.class, logCollectorBuilder::build);
+    }
+}

--- a/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorIT.java
+++ b/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorIT.java
@@ -70,6 +70,7 @@ public class LogCollectorIT {
 
         logCollector = new LogCollectorBuilder()
             .withResources(SECRET, DEPLOYMENT, CONFIG_MAP)
+            .withRootFolderPath(pathToRoot)
             .build();
 
         logCollector.setKubeClient(mockClient);

--- a/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorIT.java
+++ b/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorIT.java
@@ -1,0 +1,567 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.NamespaceList;
+import io.fabric8.kubernetes.api.model.NamespaceListBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.annotations.TestVisualSeparator;
+import io.skodjob.testframe.clients.KubeClient;
+import io.skodjob.testframe.clients.cmdClient.KubeCmdClient;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.stubbing.Answer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestVisualSeparator
+public class LogCollectorIT {
+
+    private KubeClient mockClient;
+    private KubeCmdClient mockCmdClient;
+    private NonNamespaceOperation<Namespace, NamespaceList, Resource<Namespace>> mockNamespaceOperation;
+    private KubernetesClient mockKubernetesClient = mock(KubernetesClient.class);
+
+    private final String SECRET = "secret";
+    private final String CONFIG_MAP = "configmap";
+    private final String DEPLOYMENT = "deployment";
+
+    private final String pathToRoot = "/tmp/log-collector-tests";
+    private int testCounter = 0;
+    private LogCollector logCollector;
+
+    @BeforeAll
+    public void setup() {
+        mockClient = mock(KubeClient.class);
+        mockCmdClient = mock(KubeCmdClient.class);
+        mockNamespaceOperation = mock(NonNamespaceOperation.class);
+
+        logCollector = new LogCollectorBuilder()
+            .withResources(SECRET, DEPLOYMENT, CONFIG_MAP)
+            .build();
+
+        logCollector.setKubeClient(mockClient);
+        logCollector.setKubeCmdClient(mockCmdClient);
+    }
+
+    @BeforeEach
+    public void setRootPathForCollector() {
+        when(mockKubernetesClient.namespaces()).thenReturn(mockNamespaceOperation);
+        when(mockCmdClient.inNamespace(anyString())).thenReturn(mockCmdClient);
+        when(mockClient.getClient()).thenReturn(mockKubernetesClient);
+
+        logCollector.changeRootFolderPath(getFolderPathForTest());
+    }
+
+    /**
+     * Checks "happy path" where we have single Namespace with resources, Pods, and events.
+     */
+    @Test
+    void testCollectFromNamespaceWhichAreFilledWithResources() {
+        String namespaceName = "my-happy-namespace";
+        String[] secretNames = new String[]{"secret1", "secret2"};
+        String[] deploymentNames = new String[]{"deployment1", "deployment2"};
+        String[] configMapNames = new String[]{"conf1", "conf2"};
+        String[] podNames = new String[]{"pod1", "pod2"};
+
+        mockNamespaces(namespaceName);
+        mockEvents();
+        mockSecrets(namespaceName, secretNames);
+        mockDeployments(namespaceName, deploymentNames);
+        mockConfigMaps(namespaceName, configMapNames);
+        mockPods(namespaceName, true, true, podNames);
+
+        logCollector.collectFromNamespace(namespaceName);
+
+        File rootFolder = Paths.get(getFolderPathForTest()).toFile();
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(rootFolder, 1);
+        assertFolderContainsFolders(rootFolder, namespaceName);
+
+        File namespaceFolder = rootFolder.listFiles()[0];
+
+        assertFolderForResourceTypeExistsAndContainsFiles(namespaceFolder, SECRET, secretNames);
+        assertFolderForResourceTypeExistsAndContainsFiles(namespaceFolder, DEPLOYMENT, deploymentNames);
+        assertFolderForResourceTypeExistsAndContainsFiles(namespaceFolder, CONFIG_MAP, configMapNames);
+        assertPodFolderContainsEverything(namespaceFolder, true, true, podNames);
+        assertNamespaceFolderContainsEventsLog(namespaceFolder);
+    }
+
+    @Test
+    void testCollectFromNamespaceWhichAreEmpty() {
+        String namespaceName = "my-namespace";
+
+        mockNamespaces(namespaceName);
+        mockEvents();
+
+        logCollector.collectFromNamespace(namespaceName);
+
+        File rootFolder = Paths.get(getFolderPathForTest()).toFile();
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(rootFolder, 1);
+        assertFolderContainsFolders(rootFolder, namespaceName);
+
+        File namespaceFolder = rootFolder.listFiles()[0];
+
+        assertFolderExistsAndIsNotEmpty(namespaceFolder);
+        assertNamespaceFolderContainsEventsLog(namespaceFolder);
+    }
+
+    @Test
+    void testCollectFromNamespacesWhichAreEmpty() {
+        String namespaceName1 = "my-namespace";
+        String namespaceName2 = "second-namespace";
+
+        mockNamespaces(namespaceName1, namespaceName2);
+        mockEvents();
+
+        logCollector.collectFromNamespaces(namespaceName1, namespaceName2);
+
+        File rootFolder = Paths.get(getFolderPathForTest()).toFile();
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(rootFolder, 2);
+        assertFolderContainsFolders(rootFolder, namespaceName1, namespaceName2);
+
+        Arrays.asList(rootFolder.listFiles()).forEach(namespaceFolder -> {
+            assertFolderExistsAndIsNotEmpty(namespaceFolder);
+            assertNamespaceFolderContainsEventsLog(namespaceFolder);
+        });
+    }
+
+    @Test
+    void testCollectFromNamespacesWithLabels() {
+        String namespaceName1 = "my-namespace";
+        String namespaceName2 = "second-namespace";
+        Map<String, String> labels = Map.of("first", "label");
+
+        mockNamespaces(namespaceName1);
+        mockEvents();
+        mockNamespacesWithLabels(labels, namespaceName2);
+
+        logCollector.collectFromNamespaceWithLabels(new LabelSelectorBuilder().withMatchLabels(labels).build());
+
+        File rootFolder = Paths.get(getFolderPathForTest()).toFile();
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(rootFolder, 1);
+        assertFolderContainsFolders(rootFolder, namespaceName2);
+
+        File namespaceFolder = rootFolder.listFiles()[0];
+
+        assertFolderExistsAndIsNotEmpty(namespaceFolder);
+        assertNamespaceFolderContainsEventsLog(namespaceFolder);
+    }
+
+    @Test
+    void testCollectFromNonExistentNamespace() {
+        String nonExistentNamespace = "not-the-right-namespace";
+        String namespaceName = "my-namespace";
+
+        mockNamespaces(namespaceName);
+
+        logCollector.collectFromNamespace(nonExistentNamespace);
+
+        File rootFolder = Paths.get(getFolderPathForTest()).toFile();
+
+        assertFalse(rootFolder.exists());
+    }
+
+    @Test
+    void testChangingRootFolderPath() {
+        String newPath = pathToRoot + "/my-custom-folder";
+        String namespaceName = "my-namespace";
+
+        mockNamespaces(namespaceName);
+        mockEvents();
+
+        logCollector.changeRootFolderPath(newPath);
+        logCollector.collectFromNamespace(namespaceName);
+
+        File rootFolder = Paths.get(newPath).toFile();
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(rootFolder, 1);
+        assertFolderContainsFolders(rootFolder, namespaceName);
+
+        newPath = pathToRoot + "/my-completely-different-dir";
+        logCollector.changeRootFolderPath(newPath);
+        logCollector.collectFromNamespace(namespaceName);
+
+        rootFolder = Paths.get(newPath).toFile();
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(rootFolder, 1);
+        assertFolderContainsFolders(rootFolder, namespaceName);
+    }
+
+    @Test
+    void testChangingCustomResources() throws IOException {
+        LogCollector localLogCollector = new LogCollectorBuilder()
+            .withRootFolderPath(getFolderPathForTest())
+            .withResources(SECRET)
+            .build();
+
+        localLogCollector.setKubeClient(mockClient);
+        localLogCollector.setKubeCmdClient(mockCmdClient);
+
+        String namespaceName = "my-namespace";
+        String[] secretNames = new String[]{"secret1", "secret2"};
+        String[] deploymentNames = new String[]{"deployment1", "deployment2"};
+        String[] configMapNames = new String[]{"conf1", "conf2"};
+
+        mockNamespaces(namespaceName);
+        mockEvents();
+        mockSecrets(namespaceName, secretNames);
+        mockDeployments(namespaceName, deploymentNames);
+        mockConfigMaps(namespaceName, configMapNames);
+
+        localLogCollector.collectFromNamespace(namespaceName);
+
+        File rootFolder = Paths.get(getFolderPathForTest()).toFile();
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(rootFolder, 1);
+        assertFolderContainsFolders(rootFolder, namespaceName);
+
+        File namespaceFolder = rootFolder.listFiles()[0];
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(namespaceFolder, 2);
+        assertFolderForResourceTypeExistsAndContainsFiles(namespaceFolder, SECRET, secretNames);
+        assertNamespaceFolderContainsEventsLog(namespaceFolder);
+
+        cleanUp();
+
+        localLogCollector = new LogCollectorBuilder(localLogCollector)
+            .withRootFolderPath(getFolderPathForTest())
+            .withResources(CONFIG_MAP, DEPLOYMENT)
+            .build();
+
+        localLogCollector.setKubeClient(mockClient);
+        localLogCollector.setKubeCmdClient(mockCmdClient);
+
+        localLogCollector.collectFromNamespace(namespaceName);
+
+        rootFolder = Paths.get(getFolderPathForTest()).toFile();
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(rootFolder, 1);
+        assertFolderContainsFolders(rootFolder, namespaceName);
+
+        namespaceFolder = rootFolder.listFiles()[0];
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(namespaceFolder, 3);
+        assertFolderForResourceTypeExistsAndContainsFiles(namespaceFolder, DEPLOYMENT, deploymentNames);
+        assertFolderForResourceTypeExistsAndContainsFiles(namespaceFolder, CONFIG_MAP, configMapNames);
+        assertNamespaceFolderContainsEventsLog(namespaceFolder);
+    }
+
+    @Test
+    void testCollectingLogsFromContainerWithoutInitContainers() {
+        String namespaceName = "my-namespace";
+        String[] podNames = new String[]{"pod1", "pod2"};
+
+        mockNamespaces(namespaceName);
+        mockEvents();
+        mockPods(namespaceName, false, false, podNames);
+
+        logCollector.collectFromNamespace(namespaceName);
+
+        File rootFolder = Paths.get(getFolderPathForTest()).toFile();
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(rootFolder, 1);
+        assertFolderContainsFolders(rootFolder, namespaceName);
+
+        File namespaceFolder = rootFolder.listFiles()[0];
+
+        assertPodFolderContainsEverything(namespaceFolder, false, false, podNames);
+        assertNamespaceFolderContainsEventsLog(namespaceFolder);
+    }
+
+    @Test
+    void testCollectingWithEmptyListOfCustomResources() {
+        String namespaceName = "my-namespace";
+        String[] secretNames = new String[]{"secret1", "secret2"};
+        String[] deploymentNames = new String[]{"deployment1", "deployment2"};
+
+        LogCollector localLogCollector = new LogCollectorBuilder()
+            .withRootFolderPath(getFolderPathForTest())
+            .build();
+
+        localLogCollector.setKubeClient(mockClient);
+        localLogCollector.setKubeCmdClient(mockCmdClient);
+
+        mockNamespaces(namespaceName);
+        mockEvents();
+        mockSecrets(namespaceName, secretNames);
+        mockDeployments(namespaceName, deploymentNames);
+
+        localLogCollector.collectFromNamespace(namespaceName);
+
+        File rootFolder = Paths.get(getFolderPathForTest()).toFile();
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(rootFolder, 1);
+        assertFolderContainsFolders(rootFolder, namespaceName);
+
+        File namespaceFolder = rootFolder.listFiles()[0];
+
+        assertFolderExistsAndContainsCorrectNumberOfFiles(namespaceFolder, 1);
+        assertNamespaceFolderContainsEventsLog(namespaceFolder);
+    }
+
+    @AfterEach
+    void cleanAndUpdate() {
+        reset(mockCmdClient, mockClient);
+        testCounter++;
+    }
+
+    @AfterAll
+    void cleanUp() throws IOException {
+        // remove the directories created by the tests to clean-up everything
+        FileUtils.deleteDirectory(Paths.get(pathToRoot).toFile());
+    }
+
+    private String getFolderPathForTest() {
+        return String.join("/", pathToRoot, "test", String.valueOf(testCounter));
+    }
+
+    private void mockNamespaces(String... namespaces) {
+        when(mockNamespaceOperation.withName(anyString())).thenAnswer((Answer<Resource<Namespace>>) invocation -> {
+            String namespaceName = invocation.getArgument(0);
+            Resource<Namespace> mockNamespace = mock(Resource.class);
+
+            if (Arrays.asList(namespaces).contains(namespaceName)) {
+                Namespace namespace = new NamespaceBuilder()
+                    .withNewMetadata()
+                    .withName(namespaceName)
+                    .endMetadata()
+                    .build();
+
+                when(mockNamespace.get()).thenReturn(namespace);
+            }
+
+            return mockNamespace;
+        });
+    }
+
+    private void mockNamespacesWithLabels(Map<String, String> labels, String... namespaces) {
+        List<Namespace> listOfNamespaces = new ArrayList<>();
+
+        Arrays.asList(namespaces).forEach(namespace ->
+            listOfNamespaces.add(new NamespaceBuilder()
+                .withNewMetadata()
+                .withName(namespace)
+                .withLabels(labels)
+                .endMetadata()
+                .build())
+        );
+
+        NamespaceList namespaceList = new NamespaceListBuilder()
+            .withItems(listOfNamespaces)
+            .build();
+
+        when(mockNamespaceOperation.withLabelSelector(any(LabelSelector.class))).thenAnswer((Answer<FilterWatchListDeletable<Namespace, NamespaceList, Resource<Namespace>>>) invocation -> {
+            LabelSelector labelSelector = invocation.getArgument(0);
+            FilterWatchListDeletable mockFilterWatchList = mock(FilterWatchListDeletable.class);
+
+            if (labelSelector.getMatchLabels().equals(labels)) {
+                when(mockFilterWatchList.list()).thenReturn(namespaceList);
+            }
+
+            return mockFilterWatchList;
+        });
+
+        when(mockNamespaceOperation.withName(anyString())).thenAnswer((Answer<Resource<Namespace>>) invocation -> {
+            String namespaceName = invocation.getArgument(0);
+            Resource<Namespace> mockNamespace = mock(Resource.class);
+
+            if (Arrays.asList(namespaces).contains(namespaceName)) {
+                when(mockNamespace.get()).thenReturn(listOfNamespaces.stream().filter(nspc -> nspc.equals(namespaceName)).findFirst().orElse(new Namespace()));
+            }
+
+            return mockNamespace;
+        });
+    }
+
+    private void mockPods(String namespaceName, boolean withInitContainers, boolean withMultipleContainers, String... podNames) {
+        List<Pod> pods = new ArrayList<>();
+
+        for (String podName : podNames) {
+            Container exampleContainer = new ContainerBuilder()
+                .withName(podName)
+                .withImage("random")
+                .build();
+
+            PodBuilder mockPodBuilder = new PodBuilder()
+                .withNewMetadata()
+                .withName(podName)
+                .withNamespace(namespaceName)
+                .endMetadata()
+                .editOrNewSpec()
+                .withContainers(exampleContainer)
+                .endSpec();
+
+            if (withInitContainers) {
+                Container initContainer = new ContainerBuilder(exampleContainer)
+                    .withName("init-" + podName)
+                    .build();
+
+                mockPodBuilder
+                    .editOrNewSpec()
+                    .withInitContainers(initContainer)
+                    .endSpec();
+            }
+
+            if (withMultipleContainers) {
+                Container anotherContainer = new ContainerBuilder(exampleContainer)
+                    .withName("second-" + podName)
+                    .build();
+
+                mockPodBuilder
+                    .editOrNewSpec()
+                    .addToContainers(anotherContainer)
+                    .endSpec();
+            }
+
+            Pod mockPod = mockPodBuilder.build();
+            pods.add(mockPod);
+
+            when(mockCmdClient.inNamespace(namespaceName).describe(CollectorConstants.POD, podName)).thenReturn("this is description of " + podName);
+            when(mockCmdClient.inNamespace(namespaceName).logs(any(), any())).thenAnswer((Answer<String>) invocation -> {
+                String pod = invocation.getArgument(0);
+                String container = invocation.getArgument(1);
+
+                return "this is log for pod: " + pod + " and container: " + container;
+            });
+        }
+
+        when(mockClient.listPods(namespaceName)).thenReturn(pods);
+    }
+
+    private void mockSecrets(String namespaceName, String... secretNames) {
+        List<String> secretNamesList = Arrays.asList(secretNames);
+
+        for (String secretName : secretNames) {
+            when(mockCmdClient.inNamespace(namespaceName).getResourceAsYaml(SECRET, secretName))
+                .thenReturn("this is description of Secret: " + secretName);
+        }
+
+        when(mockCmdClient.inNamespace(namespaceName).list(SECRET)).thenReturn(secretNamesList);
+    }
+
+    private void mockConfigMaps(String namespaceName, String... configMapNames) {
+        List<String> configMapNamesList = Arrays.asList(configMapNames);
+
+        for (String configName : configMapNames) {
+            when(mockCmdClient.inNamespace(namespaceName).getResourceAsYaml(CONFIG_MAP, configName))
+                .thenReturn("this is description of ConfigMap: " + configName);
+        }
+
+        when(mockCmdClient.inNamespace(namespaceName).list(CONFIG_MAP)).thenReturn(configMapNamesList);
+    }
+
+    private void mockDeployments(String namespaceName, String... deploymentNames) {
+        List<String> deploymentNamesList = Arrays.asList(deploymentNames);
+
+        for (String deploymentName : deploymentNames) {
+            when(mockCmdClient.inNamespace(namespaceName).getResourceAsYaml(anyString(), anyString()))
+                .thenReturn("this is description of Deployment: " + deploymentName);
+        }
+
+        when(mockCmdClient.inNamespace(namespaceName).list(DEPLOYMENT)).thenReturn(deploymentNamesList);
+    }
+
+    private void mockEvents() {
+        when(mockCmdClient.inNamespace(anyString()).getEvents()).thenReturn("these are events from this namespace");
+    }
+
+    private void assertNamespaceFolderContainsEventsLog(File namespaceFolder) {
+        assertTrue(Arrays.asList(namespaceFolder.list()).contains("events.log"));
+    }
+
+    private void assertFolderForResourceTypeExistsAndContainsFiles(File namespaceFolder, String resourceType, String... resourceNames) {
+        File resourceFolder = Arrays.stream(namespaceFolder.listFiles()).filter(file -> file.getName().equals(resourceType)).findFirst().get();
+
+        assertFolderExistsAndIsNotEmpty(resourceFolder);
+        assertFolderContainsCorrectResourceFiles(resourceFolder, resourceNames);
+    }
+
+    private void assertFolderExistsAndIsNotEmpty(File folder) {
+        assertNotNull(folder);
+        assertTrue(Objects.requireNonNull(folder.list()).length != 0);
+    }
+
+    private void assertFolderExistsAndContainsCorrectNumberOfFiles(File folder, int expectedNumOfFiles) {
+        assertNotNull(folder);
+        assertTrue(Objects.requireNonNull(folder.list()).length == expectedNumOfFiles);
+    }
+
+    private void assertFolderContainsFolders(File folder, String... folders) {
+        List<String> expectedFolderNames = Arrays.asList(folders);
+        List<String> namesOfFolders = Arrays.stream(folder.listFiles())
+            .filter(File::isDirectory)
+            .map(File::getName)
+            .toList();
+
+        assertTrue(namesOfFolders.containsAll(expectedFolderNames));
+    }
+
+    private void assertFolderContainsCorrectResourceFiles(File folder, String... resourceNames) {
+        List<String> folderFiles = Arrays.asList(Objects.requireNonNull(folder.list()));
+        List<String> expectedFiles = Arrays.stream(resourceNames).map(it -> it + ".yaml").toList();
+
+        assertTrue(folderFiles.containsAll(expectedFiles));
+    }
+
+    private void assertPodFolderContainsEverything(
+        File namespaceFolder,
+        boolean withInitContainers,
+        boolean withMultipleContainers,
+        String... podNames
+    ) {
+        List<String> podFiles = Arrays.asList(Arrays.stream(namespaceFolder.listFiles())
+            .filter(file -> file.getName().equals(CollectorConstants.POD))
+            .findFirst()
+            .get()
+            .list());
+
+        for (String podName : podNames) {
+            assertTrue(podFiles.contains(LogCollectorUtils.getLogFileNameForPodDescription(podName)));
+            assertTrue(podFiles.contains(LogCollectorUtils.getLogFileNameForPodContainer(podName, podName)));
+
+            if (withInitContainers) {
+                assertTrue(podFiles.contains(LogCollectorUtils.getLogFileNameForPodContainer(podName, "init-" + podName)));
+            }
+
+            if (withMultipleContainers) {
+                assertTrue(podFiles.contains(LogCollectorUtils.getLogFileNameForPodContainer(podName, "second-" + podName)));
+            }
+        }
+    }
+}

--- a/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorUtilsTest.java
+++ b/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorUtilsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe;
+
+import io.skodjob.testframe.annotations.TestVisualSeparator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestVisualSeparator
+public class LogCollectorUtilsTest {
+
+    @Test
+    void testYamlFileNameForResource() {
+        String resourceName = "secret-RESOURCE";
+        String expectedFileName = "secret-resource.yaml";
+
+        assertEquals(expectedFileName, LogCollectorUtils.getYamlFileNameForResource(resourceName));
+    }
+
+    @Test
+    void testLogFileNameForResource() {
+        String resourceName = "pod-name-RES";
+        String expectedFileName = "pod-name-res.log";
+
+        assertEquals(expectedFileName, LogCollectorUtils.getLogFileNameForResource(resourceName));
+    }
+
+    @Test
+    void testLogFileNameForPodAndContainer() {
+        String podName = "my-cluster-323232";
+        String containerName = "pavel";
+        String expectedFileName = "logs-pod-" + podName + "-container-" + containerName + ".log";
+
+        assertEquals(expectedFileName, LogCollectorUtils.getLogFileNameForPodContainer(podName, containerName));
+    }
+
+    @Test
+    void testLogFileNameForPodDescription() {
+        String podName = "my-ultimate-cluster-3000";
+        String expectedFileName = "describe-pod-" + podName + ".log";
+
+        assertEquals(expectedFileName, LogCollectorUtils.getLogFileNameForPodDescription(podName));
+    }
+
+    @Test
+    void testFullDirPathWithNamespace() {
+        String rootPathDir = "/tmp/logs";
+        String namespaceName = "my-namespace";
+        String expectedFullPath = rootPathDir + "/" + namespaceName;
+
+        assertEquals(expectedFullPath, LogCollectorUtils.getFullDirPathWithNamespace(rootPathDir, namespaceName));
+    }
+
+    @Test
+    void testFullPathDirWithNamespaceAndResourceType() {
+        String rootPathDir = "/tmp/logs";
+        String namespaceName = "my-namespace";
+        String resourceType = "ULTIMATE";
+        String expectedFullPath = rootPathDir + "/" + namespaceName + "/" + resourceType.toLowerCase(Locale.ROOT);
+
+        assertEquals(expectedFullPath, LogCollectorUtils.getFullDirPathWithNamespaceAndForResourceType(rootPathDir, namespaceName, resourceType));
+    }
+
+    @Test
+    void testFullPathForFolderPathAndFileName() {
+        String fullNamespacePath = "/tmp/logs/my-namespace";
+        String fileName = "tonda.yaml";
+        String expectedFullPath = fullNamespacePath + "/" + fileName;
+
+        assertEquals(expectedFullPath, LogCollectorUtils.getFullPathForFolderPathAndFileName(fullNamespacePath, fileName));
+    }
+}

--- a/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorUtilsTest.java
+++ b/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorUtilsTest.java
@@ -63,7 +63,8 @@ public class LogCollectorUtilsTest {
         String resourceType = "ULTIMATE";
         String expectedFullPath = rootPathDir + "/" + namespaceName + "/" + resourceType.toLowerCase(Locale.ROOT);
 
-        assertEquals(expectedFullPath, LogCollectorUtils.getFullDirPathWithNamespaceAndForResourceType(rootPathDir, namespaceName, resourceType));
+        assertEquals(expectedFullPath, LogCollectorUtils.getNamespaceFullDirPathForResourceType(
+            LogCollectorUtils.getFullDirPathWithNamespace(rootPathDir, namespaceName), resourceType));
     }
 
     @Test
@@ -73,5 +74,14 @@ public class LogCollectorUtilsTest {
         String expectedFullPath = fullNamespacePath + "/" + fileName;
 
         assertEquals(expectedFullPath, LogCollectorUtils.getFullPathForFolderPathAndFileName(fullNamespacePath, fileName));
+    }
+
+    @Test
+    void testGetFolderPath() {
+        String rootPath = "/tmp/logs";
+        String folderPath = "additional/path/to/folder";
+        String expectedFolderPath = rootPath + "/" + folderPath;
+
+        assertEquals(expectedFolderPath, LogCollectorUtils.getFolderPath(rootPath, folderPath));
     }
 }

--- a/test-frame-test-examples/pom.xml
+++ b/test-frame-test-examples/pom.xml
@@ -22,7 +22,6 @@
 
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <it.skip>true</it.skip>
     </properties>
 
     <dependencies>
@@ -33,6 +32,10 @@
         <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-kubernetes</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.skodjob</groupId>
+            <artifactId>test-frame-log-collector</artifactId>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -95,44 +98,4 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven.surefire.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>verify</goal>
-                            <goal>integration-test</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <skipITs>${it.skip}</skipITs>
-                    <forkCount>1</forkCount>
-                    <includes>
-                        <include>io.skodjob.testframe.test.integration.**</include>
-                    </includes>
-                    <properties>
-                        <configurationParameters>
-                            junit.jupiter.extensions.autodetection.enabled = true
-                        </configurationParameters>
-                    </properties>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <profiles>
-        <profile>
-            <id>integration</id>
-            <properties>
-                <it.skip>false</it.skip>
-            </properties>
-        </profile>
-    </profiles>
-
 </project>

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/AbstractIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/AbstractIT.java
@@ -3,6 +3,7 @@ package io.skodjob.testframe.test.integration;
 import io.skodjob.testframe.LoggerUtils;
 import io.skodjob.testframe.annotations.ResourceManager;
 import io.skodjob.testframe.annotations.TestVisualSeparator;
+import io.skodjob.testframe.resources.DeploymentType;
 import io.skodjob.testframe.resources.KubeResourceManager;
 import io.skodjob.testframe.resources.NamespaceType;
 import io.skodjob.testframe.resources.ServiceAccountType;
@@ -19,7 +20,8 @@ public abstract class AbstractIT {
     static {
         KubeResourceManager.getInstance().setResourceTypes(
                 new NamespaceType(),
-                new ServiceAccountType()
+                new ServiceAccountType(),
+                new DeploymentType()
         );
         KubeResourceManager.getInstance().addCreateCallback(r -> {
             isCreateHandlerCalled.set(true);

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe.test.integration;
+
+import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.skodjob.testframe.LogCollector;
+import io.skodjob.testframe.LogCollectorBuilder;
+import io.skodjob.testframe.LogCollectorUtils;
+import io.skodjob.testframe.resources.KubeResourceManager;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class LogCollectorIT extends AbstractIT {
+    private final String folderRoot = "/tmp/log-collector-examples";
+    private final String[] resourcesToBeCollected = new String[] {"secret", "configmap", "deployment"};
+    private final LogCollector logCollector = new LogCollectorBuilder()
+        .withResources(resourcesToBeCollected)
+        .build();
+
+    /**
+     * Test checks that LogCollector is able to collect from multiple namespaces, where in each are different resources
+     * that are specified by the user.
+     */
+    @Test
+    void testCollectFromMultipleNamespacesWithDifferentResources() {
+        String fullFolderPath = folderRoot + "/test1";
+
+        String namespaceName1 = "my-namespace1";
+        String namespaceName2 = "my-namespace2";
+
+        String configMapName = "my-config-map";
+        String secretName = "my-secret";
+        String deploymentName = "my-deployment";
+
+        int deploymentReplicas = 2;
+
+        logCollector.changeRootFolderPath(fullFolderPath);
+
+        KubeResourceManager.getInstance().createResourceWithWait(
+            new NamespaceBuilder()
+                .editOrNewMetadata()
+                    .withName(namespaceName1)
+                .endMetadata()
+                .build(),
+            new NamespaceBuilder()
+                .editOrNewMetadata()
+                    .withName(namespaceName2)
+                .endMetadata()
+                .build()
+        );
+
+        KubeResourceManager.getInstance().createResourceWithWait(
+            new DeploymentBuilder()
+                .editOrNewMetadata()
+                    .withNamespace(namespaceName1)
+                    .withName(deploymentName)
+                .endMetadata()
+                .editOrNewSpec()
+                    .withReplicas(deploymentReplicas)
+                    .withSelector(new LabelSelectorBuilder()
+                        .withMatchLabels(Map.of("app", "nginx"))
+                        .build())
+                    .editOrNewTemplate()
+                        .editOrNewMetadata()
+                            .withLabels(Map.of("app", "nginx"))
+                        .endMetadata()
+                        .editOrNewSpec()
+                            .addToContainers(new ContainerBuilder()
+                                .withName("nginx")
+                                .withImage("nginx:latest")
+                                .withPorts(new ContainerPortBuilder()
+                                    .withContainerPort(80)
+                                    .build())
+                                .addAllToVolumeMounts(List.of(
+                                    new VolumeMountBuilder()
+                                        .withName("nginx-dir")
+                                        .withMountPath("/etc/nginx/conf.d/")
+                                        .build(),
+                                    new VolumeMountBuilder()
+                                        .withName("nginx-empty")
+                                        .withMountPath("/var/cache/nginx/client_temp")
+                                        .build(),
+                                    new VolumeMountBuilder()
+                                        .withName("nginx-run")
+                                        .withMountPath("/var/run/")
+                                        .build()
+                                ))
+                                .build())
+                .addToVolumes(
+                    new VolumeBuilder()
+                        .withName("nginx-dir")
+                        .withNewEmptyDir()
+                        .endEmptyDir()
+                        .build(),
+                    new VolumeBuilder()
+                        .withName("nginx-empty")
+                        .withNewEmptyDir()
+                        .endEmptyDir()
+                        .build(),
+                    new VolumeBuilder()
+                        .withName("nginx-run")
+                        .withNewEmptyDir()
+                        .endEmptyDir()
+                        .build())
+                        .endSpec()
+                    .endTemplate()
+                .endSpec()
+                .build(),
+            new SecretBuilder()
+                .editOrNewMetadata()
+                    .withNamespace(namespaceName1)
+                    .withName(secretName)
+                .endMetadata()
+                .withData(Map.of("data", Base64.getEncoder().encodeToString("top-secret-password-for-ultimate-access-to-everything".getBytes(StandardCharsets.UTF_8))))
+                .build(),
+            new ConfigMapBuilder()
+                .editOrNewMetadata()
+                    .withNamespace(namespaceName2)
+                    .withName(configMapName)
+                .endMetadata()
+                .withData(Map.of("config", "configuration-of-my-ultimate-machine"))
+                .build()
+        );
+
+        logCollector.collectFromNamespaces(namespaceName1, namespaceName2);
+
+        List<String> podNames = KubeResourceManager.getKubeClient()
+            .listPods(namespaceName1).stream().map(pod -> pod.getMetadata().getName()).toList();
+        List<String> secretNames = KubeResourceManager.getKubeClient().getClient().secrets().inNamespace(namespaceName1)
+            .list().getItems().stream().map(secret -> secret.getMetadata().getName()).toList();
+
+        File rootFolder = Paths.get(fullFolderPath).toFile();
+
+        assertNotNull(rootFolder);
+
+        File[] namespaceFolders = rootFolder.listFiles();
+
+        assertNotNull(namespaceFolders);
+        assertEquals(2, namespaceFolders.length);
+
+        Arrays.stream(namespaceFolders).forEach(namespaceFolder -> {
+            List<File> namespaceFolderFiles = Arrays.asList(Objects.requireNonNull(namespaceFolder.listFiles()));
+            List<String> namespaceFolderFileNames = namespaceFolderFiles.stream().map(File::getName).toList();
+
+            if (namespaceFolder.getName().equals(namespaceName1)) {
+                assertTrue(namespaceFolderFileNames.contains("events.log"));
+                assertTrue(namespaceFolderFileNames.contains("pod"));
+
+                File podFolder = namespaceFolderFiles.stream()
+                    .filter(file -> file.getName().equals("pod")).findFirst().get();
+                List<File> podFolderFiles = Arrays.asList(Objects.requireNonNull(podFolder.listFiles()));
+                List<String> podFolderFileNames = podFolderFiles.stream().map(File::getName).toList();
+
+                assertEquals(4, podFolderFiles.size());
+                podNames.forEach(podName -> {
+                    assertTrue(podFolderFileNames.contains(LogCollectorUtils.getLogFileNameForPodDescription(podName)));
+                    assertTrue(podFolderFileNames.contains(
+                        LogCollectorUtils.getLogFileNameForPodContainer(podName, "nginx")));
+                });
+
+                assertTrue(namespaceFolderFileNames.contains("deployment"));
+
+                File depFolder = namespaceFolderFiles.stream()
+                    .filter(file -> file.getName().equals("deployment")).findFirst().get();
+                List<File> depFolderFiles = Arrays.asList(Objects.requireNonNull(depFolder.listFiles()));
+                List<String> depFolderFileNames = depFolderFiles.stream().map(File::getName).toList();
+
+                assertEquals(1, depFolderFileNames.size());
+                assertEquals(depFolderFileNames.get(0), LogCollectorUtils.getYamlFileNameForResource(deploymentName));
+
+                assertTrue(namespaceFolderFileNames.contains("secret"));
+
+                File secretFolder = namespaceFolderFiles.stream()
+                    .filter(file -> file.getName().equals("secret")).findFirst().get();
+                List<File> secretFolderFiles = Arrays.asList(Objects.requireNonNull(secretFolder.listFiles()));
+                List<String> secretFolderFileNames = secretFolderFiles.stream().map(File::getName).toList();
+
+                assertTrue(secretFolderFileNames.contains(LogCollectorUtils.getYamlFileNameForResource(secretName)));
+                secretNames.forEach(
+                    secret -> assertTrue(secretFolderFileNames.contains(LogCollectorUtils.getYamlFileNameForResource(secret)))
+                );
+            } else {
+                assertFalse(namespaceFolderFileNames.contains("pod"));
+                assertFalse(namespaceFolderFileNames.contains("deployment"));
+                assertTrue(namespaceFolderFileNames.contains("configmap"));
+
+                File configMapFolder = namespaceFolderFiles.stream()
+                    .filter(file -> file.getName().equals("configmap")).findFirst().get();
+                List<File> configMapFolderFiles = Arrays.asList(Objects.requireNonNull(configMapFolder.listFiles()));
+                List<String> configMapFolderFileNames = configMapFolderFiles.stream().map(File::getName).toList();
+
+                assertTrue(configMapFolderFileNames.contains(LogCollectorUtils.getYamlFileNameForResource(configMapName)));
+            }
+        });
+    }
+
+    @AfterEach
+    void cleanUpFiles() throws IOException {
+        // remove the directories created by the tests to clean-up everything
+        FileUtils.deleteDirectory(Paths.get(folderRoot).toFile());
+    }
+}

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
@@ -45,7 +45,8 @@ public class LogCollectorIT extends AbstractIT {
      */
     @Test
     void testCollectFromMultipleNamespacesWithDifferentResources() {
-        String fullFolderPath = folderRoot + "/test1";
+        String folderPath = "test1";
+        String fullFolderPath = LogCollectorUtils.getFolderPath(folderRoot, folderPath);
 
         String namespaceName1 = "my-namespace1";
         String namespaceName2 = "my-namespace2";
@@ -55,8 +56,6 @@ public class LogCollectorIT extends AbstractIT {
         String deploymentName = "my-deployment";
 
         int deploymentReplicas = 2;
-
-        logCollector.changeRootFolderPath(fullFolderPath);
 
         KubeResourceManager.getInstance().createResourceWithWait(
             new NamespaceBuilder()
@@ -144,7 +143,7 @@ public class LogCollectorIT extends AbstractIT {
                 .build()
         );
 
-        logCollector.collectFromNamespaces(namespaceName1, namespaceName2);
+        logCollector.collectFromNamespacesToFolder(List.of(namespaceName1, namespaceName2), folderPath);
 
         List<String> podNames = KubeResourceManager.getKubeClient()
             .listPods(namespaceName1).stream().map(pod -> pod.getMetadata().getName()).toList();

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
@@ -36,6 +36,7 @@ public class LogCollectorIT extends AbstractIT {
     private final String[] resourcesToBeCollected = new String[] {"secret", "configmap", "deployment"};
     private final LogCollector logCollector = new LogCollectorBuilder()
         .withResources(resourcesToBeCollected)
+        .withRootFolderPath(folderRoot)
         .build();
 
     /**


### PR DESCRIPTION
## Description

This PR implements LogCollector component, which is/should be used for collecting logs, events, Pod descriptions, and finally resource YAMLs for all resources that user specifies.

The LogCollector is able to collect logs from one namespace, multiple namespaces, or users can pick Namespaces that matches some LabelSelector.

Closes #7 

## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
