### PR TITLE
Add method for save configured env vars

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
@@ -124,11 +124,7 @@ public class TestEnvironmentVariables {
         Path logPath = Path.of(testLogDir);
         Files.createDirectories(logPath);
 
-        LinkedHashMap<String, String> toSave = new LinkedHashMap<>();
-
-        values.forEach((key, value) -> {
-            toSave.put(key, value);
-        });
+        LinkedHashMap<String, String> toSave = new LinkedHashMap<>(values);
 
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         mapper.writerWithDefaultPrettyPrinter().writeValue(logPath.resolve("config.yaml").toFile(), toSave);

--- a/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
@@ -47,22 +47,23 @@ public class TestEnvironmentVariables {
      * {@link TestEnvironmentVariables} object initialization, where the config file is loaded to {@link #yamlData}
      * if possible.
      *
-     * @param envMap Map containing the environment variables. Used mainly for testing purposes.
+     * @param envMap    Map containing the environment variables. Used mainly for testing purposes.
      */
     public TestEnvironmentVariables(Map<String, String> envMap) {
         this.envMap = envMap;
         this.configFilePath = envMap.getOrDefault(configFilePathEnv,
-                Paths.get(System.getProperty("user.dir"), "config.yaml").toAbsolutePath().toString());
+            Paths.get(System.getProperty("user.dir"), "config.yaml").toAbsolutePath().toString());
         this.yamlData = loadConfigurationFile();
     }
 
     /**
      * Method which returns the value from env variable or its default in String.
      *
-     * @param envVarName   environment variable name
-     * @param defaultValue default value, which should be used if the env var is empty and the config file
-     *                     doesn't contain it
-     * @return value from env var/config file or default
+     * @param envVarName        environment variable name
+     * @param defaultValue      default value, which should be used if the env var is empty and the config file
+     *                          doesn't contain it
+     *
+     * @return  value from env var/config file or default
      */
     public String getOrDefault(String envVarName, String defaultValue) {
         return getOrDefault(envVarName, String::toString, defaultValue);
@@ -72,19 +73,20 @@ public class TestEnvironmentVariables {
      * Method which returns the value from env variable or its default in the specified type.
      * It also checks if the env var is specified in the configuration file before applying the default.
      *
-     * @param envVarName   environment variable name
-     * @param converter    converter to the desired type
-     * @param defaultValue default value, which should be used if the env var is empty and the config file
-     *                     doesn't contain it
-     * @param <T>          desired type
-     * @return value from env var/config file or default
+     * @param envVarName        environment variable name
+     * @param converter         converter to the desired type
+     * @param defaultValue      default value, which should be used if the env var is empty and the config file
+     *                          doesn't contain it
+     *
+     * @return  value from env var/config file or default
+     * @param <T>   desired type
      */
     public <T> T getOrDefault(String envVarName, Function<String, T> converter, T defaultValue) {
         String value = envMap.get(envVarName) != null ?
-                envMap.get(envVarName) :
-                (Objects.requireNonNull(yamlData).get(envVarName) != null ?
-                        yamlData.get(envVarName).toString() :
-                        null);
+            envMap.get(envVarName) :
+            (Objects.requireNonNull(yamlData).get(envVarName) != null ?
+                yamlData.get(envVarName).toString() :
+                null);
 
         T returnValue = defaultValue;
 
@@ -101,7 +103,7 @@ public class TestEnvironmentVariables {
      * the default path (in the `config.yaml` file on the `user.dir` path).
      * If the file doesn't exist, the info log is printed and empty Map is returned.
      *
-     * @return Map with env variables and their values, or empty Map in case of not existing file
+     * @return  Map with env variables and their values, or empty Map in case of not existing file
      */
     protected Map<String, Object> loadConfigurationFile() {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
@@ -141,12 +143,12 @@ public class TestEnvironmentVariables {
         LOGGER.info("Used environment variables:");
 
         values.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .forEach(entry -> {
-                    if (!Objects.equals(entry.getValue(), "null")) {
-                        LOGGER.info(debugFormat, entry.getKey(), entry.getValue());
-                    }
-                });
+            .sorted(Map.Entry.comparingByKey())
+            .forEach(entry -> {
+                if (!Objects.equals(entry.getValue(), "null")) {
+                    LOGGER.info(debugFormat, entry.getKey(), entry.getValue());
+                }
+            });
 
         LoggerUtils.logSeparator("-", 30);
     }

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/TestEnvironmentVariablesTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/TestEnvironmentVariablesTest.java
@@ -3,9 +3,14 @@ package io.skodjob.testframe.clients;
 import io.skodjob.testframe.environment.TestEnvironmentVariables;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestEnvironmentVariablesTest {
 
@@ -13,12 +18,14 @@ public class TestEnvironmentVariablesTest {
     void testGetEnvVariablesCorrectly() {
         assertEquals(MyEnvs.MY_ENV, "this");
         assertEquals(MyEnvs.SECOND_ENV, "23");
+        assertTrue(Files.exists(Paths.get(System.getProperty("user.dir"))
+                .resolve("target").resolve("config.yaml")));
     }
 
     public static class MyEnvs {
         private static final Map<String, String> ENVS_MAP = Map.of(
-            "MY_ENV", "this",
-            "THIRD_ENV", "that"
+                "MY_ENV", "this",
+                "THIRD_ENV", "that"
         );
 
         public static final TestEnvironmentVariables ENVIRONMENT_VARIABLES = new TestEnvironmentVariables(ENVS_MAP);
@@ -27,6 +34,12 @@ public class TestEnvironmentVariablesTest {
 
         static {
             ENVIRONMENT_VARIABLES.logEnvironmentVariables();
+            try {
+                ENVIRONMENT_VARIABLES.saveConfigurationFile(Paths.get(System.getProperty("user.dir"))
+                        .resolve("target").toAbsolutePath().toString());
+            } catch (IOException e) {
+                fail("Env vars not saved");
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Method for save env vars configured in environment, to easy reproduce next test run.


## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
