### PR TITLE
[metrics collector] fix timeout + more verbose in case of failure

### DIFF
--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -440,13 +440,13 @@ public class MetricsCollector {
                         if (metricsData.isEmpty()) {
                             status.setMessage("No pods found or no metrics available from pods.");
                             status.setType(MetricsCollectionStatus.Type.NO_DATA);
-                            LOGGER.error("Metrics collection failed: {}", status.getMessage());
+                            LOGGER.warn("Metrics collection failed: {}", status.getMessage());
                             return false;
                         }
                         if (metricsData.values().stream().anyMatch(String::isEmpty)) {
                             status.setMessage("Incomplete metrics data collected.");
                             status.setType(MetricsCollectionStatus.Type.INCOMPLETE_DATA);
-                            LOGGER.error("Metrics collection incomplete: Some pods returned empty metrics.");
+                            LOGGER.warn("Metrics collection incomplete: Some pods returned empty metrics.");
                             return false;
                         }
                         this.collectedData = metricsData;
@@ -455,7 +455,7 @@ public class MetricsCollector {
                         status.setMessage(e.getMessage());
                         status.setType(MetricsCollectionStatus.Type.ERROR);
                         status.setException(e);
-                        LOGGER.error("Error during metrics collection: {}", status.getMessage(), e);
+                        LOGGER.warn("Error during metrics collection: {}", status.getMessage(), e);
                         return false;
                     }
                 },

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -440,11 +440,13 @@ public class MetricsCollector {
                         if (metricsData.isEmpty()) {
                             status.setMessage("No pods found or no metrics available from pods.");
                             status.setType(MetricsCollectionStatus.Type.NO_DATA);
+                            LOGGER.error("Metrics collection failed: {}", status.getMessage());
                             return false;
                         }
                         if (metricsData.values().stream().anyMatch(String::isEmpty)) {
                             status.setMessage("Incomplete metrics data collected.");
                             status.setType(MetricsCollectionStatus.Type.INCOMPLETE_DATA);
+                            LOGGER.error("Metrics collection incomplete: Some pods returned empty metrics.");
                             return false;
                         }
                         this.collectedData = metricsData;
@@ -453,12 +455,14 @@ public class MetricsCollector {
                         status.setMessage(e.getMessage());
                         status.setType(MetricsCollectionStatus.Type.ERROR);
                         status.setException(e);
+                        LOGGER.error("Error during metrics collection: {}", status.getMessage(), e);
                         return false;
                     }
                 },
-                () -> LOGGER.error("Failed to collect metrics: {}", status.getMessage())
+                () -> LOGGER.error("Failed to collect metrics within the allowed time: {}", status.getMessage())
             );
         } catch (WaitException we) {
+            LOGGER.error("Metrics collection terminated due to timeout: {}", we.getMessage());
             throw determineExceptionFromStatus(status);
         }
     }
@@ -521,7 +525,7 @@ public class MetricsCollector {
      *                                    collection logic.
      */
     public final void collectMetricsFromPods() throws MetricsCollectionException {
-        collectMetricsFromPods(Duration.ofSeconds(TestFrameConstants.GLOBAL_TIMEOUT_MEDIUM).toMillis());
+        collectMetricsFromPods(TestFrameConstants.GLOBAL_TIMEOUT_MEDIUM);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR fixes a problem with timeout when I accidentally put it inside `Duration.ofSeconds(...` a `TestFrameConstants.GLOBAL_TIMEOUT_MEDIUM`, which would mean that it would take a lot of seconds to trigger timeout.

## Type of Change

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
