### PR TITLE
Add ability to log all managed resoruces

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/KubeClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/KubeClient.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.skodjob.testframe.LoggerUtils;
+import io.skodjob.testframe.utils.LoggerUtils;
 import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.TestFrameEnv;
 import io.skodjob.testframe.executor.Exec;

--- a/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
@@ -7,7 +7,7 @@ package io.skodjob.testframe.environment;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import io.skodjob.testframe.LoggerUtils;
+import io.skodjob.testframe.utils.LoggerUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/test-frame-common/src/main/java/io/skodjob/testframe/listeners/TestVisualSeparatorExtension.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/listeners/TestVisualSeparatorExtension.java
@@ -4,7 +4,7 @@
  */
 package io.skodjob.testframe.listeners;
 
-import io.skodjob.testframe.LoggerUtils;
+import io.skodjob.testframe.utils.LoggerUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.AfterEachCallback;

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.skodjob.testframe.LoggerUtils;
+import io.skodjob.testframe.utils.LoggerUtils;
 import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.TestFrameEnv;
 import io.skodjob.testframe.clients.KubeClient;
@@ -33,6 +33,7 @@ import io.skodjob.testframe.clients.cmdClient.Oc;
 import io.skodjob.testframe.interfaces.NamespacedResourceType;
 import io.skodjob.testframe.interfaces.ResourceType;
 import io.skodjob.testframe.wait.Wait;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -183,6 +184,37 @@ public class KubeResourceManager {
                             resource
                     ));
         }
+    }
+
+    /**
+     * Logs all managed resources across all test contexts with set log level
+     *
+     * @param logLevel log4j2 log level
+     */
+    public void printAllResources(Level logLevel) {
+        LOGGER.log(logLevel, "Printing all managed resources from all test contexts");
+        STORED_RESOURCES.forEach((testName, resources) -> {
+            LOGGER.log(logLevel, "Context: {}", testName);
+            resources.forEach(resourceItem -> {
+                if (resourceItem.resource() != null) {
+                    LoggerUtils.logResource("Managed resource:", logLevel, resourceItem.resource());
+                }
+            });
+        });
+    }
+
+    /**
+     * Logs all managed resources in current test context with set log level
+     *
+     * @param logLevel log4j2 log level
+     */
+    public void printCurrentResources(Level logLevel) {
+        LOGGER.log(logLevel, "Printing all managed resources from current test context");
+        STORED_RESOURCES.get(getTestContext().getDisplayName()).forEach(resourceItem -> {
+            if (resourceItem.resource() != null) {
+                LoggerUtils.logResource("Managed resource:", logLevel, resourceItem.resource());
+            }
+        });
     }
 
     /**

--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/LoggerUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/LoggerUtils.java
@@ -2,11 +2,12 @@
  * Copyright Skodjob authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.skodjob.testframe;
+package io.skodjob.testframe.utils;
 
 import java.util.Collections;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -57,12 +58,24 @@ public final class LoggerUtils {
      * @param <T> The type of the resources.
      */
     public static <T extends HasMetadata> void logResource(String operation, T resource) {
+        logResource(operation, Level.INFO, resource);
+    }
+
+    /**
+     * Log resource with correct format
+     *
+     * @param operation operation with resource
+     * @param logLevel log level
+     * @param resource resource
+     * @param <T> The type of the resources.
+     */
+    public static <T extends HasMetadata> void logResource(String operation, Level logLevel, T resource) {
         if (resource.getMetadata().getNamespace() == null) {
-            LOGGER.info(LoggerUtils.RESOURCE_LOGGER_PATTERN,
+            LOGGER.log(logLevel, LoggerUtils.RESOURCE_LOGGER_PATTERN,
                     operation, resource.getKind(),
                     resource.getMetadata().getName());
         } else {
-            LOGGER.info(LoggerUtils.RESOURCE_WITH_NAMESPACE_LOGGER_PATTERN,
+            LOGGER.log(logLevel, LoggerUtils.RESOURCE_WITH_NAMESPACE_LOGGER_PATTERN,
                     operation,
                     resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
         }

--- a/test-frame-common/src/test/java/io/skodjob/testframe/helper/TestLoggerAppender.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/helper/TestLoggerAppender.java
@@ -1,0 +1,28 @@
+package io.skodjob.testframe.helper;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class TestLoggerAppender extends AbstractAppender {
+    private final List<LogEvent> logEvents = new LinkedList<>();
+
+    public TestLoggerAppender(String name) {
+        super(name, null, null, true, null);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        logEvents.add(event.toImmutable());
+    }
+
+    public List<LogEvent> getLogEvents() {
+        return new LinkedList<>(logEvents);
+    }
+
+    public void clean() {
+        logEvents.clear();
+    }
+}

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/AbstractIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/AbstractIT.java
@@ -1,6 +1,6 @@
 package io.skodjob.testframe.test.integration;
 
-import io.skodjob.testframe.LoggerUtils;
+import io.skodjob.testframe.utils.LoggerUtils;
 import io.skodjob.testframe.annotations.ResourceManager;
 import io.skodjob.testframe.annotations.TestVisualSeparator;
 import io.skodjob.testframe.resources.DeploymentType;

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.testframe.clients.KubeClusterException;
 import io.skodjob.testframe.resources.KubeResourceManager;
+import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +50,7 @@ public final class KubeResourceManagerCleanerIT extends AbstractIT {
         KubeResourceManager.getInstance().createOrUpdateResourceWithWait(ns);
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName3).get()
                 .getMetadata().getLabels().get("test-label"));
+        KubeResourceManager.getInstance().printAllResources(Level.INFO);
     }
 
     @Test


### PR DESCRIPTION
## Description

Add ability for end user print anytime all managed resources in current test context or in all contexts


## Type of Change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
