### PR TITLE
Fix compiler warning about old sisu module targetet for java6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <junit.platform.version>1.10.2</junit.platform.version>
         <maven.surefire.version>3.2.2</maven.surefire.version>
         <jackson-dataformat-yaml.version>2.17.1</jackson-dataformat-yaml.version>
+        <org.eclipse.sisu.version>0.3.5</org.eclipse.sisu.version>
 
         <it.skip>true</it.skip>
         <!--suppress UnresolvedMavenProperty -->
@@ -213,6 +214,11 @@
                 <artifactId>commons-io</artifactId>
                 <version>${apache.commons.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>org.eclipse.sisu.inject</artifactId>
+                <version>${org.eclipse.sisu.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description

Last compiler issue is caused in test-example module
```
[WARNING] Supported source version 'RELEASE_6' from annotation processor 'org.eclipse.sisu.scanners.index.SisuIndexAPT6' less than -source '17'
```

## Type of Change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ x I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit/integration tests pass locally with my changes
