### PR TITLE
Deploy own scraper pod in metrics collector when user wants

### DIFF
--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -115,7 +115,7 @@ public class MetricsCollector {
          *
          * @return this builder instance to allow for method chaining
          */
-        public Builder withOwnScraperPod() {
+        public Builder withDeployScraperPod() {
             this.deployScraperPod = true;
             return this;
         }

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
@@ -114,7 +114,7 @@ public final class MetricsCollectorIT extends AbstractIT {
             .getMetadata().getName()));
 
         // Update metrics collector with different image
-        MetricsCollector collector2 = mcBuilder.withScraperPodImage("quay.io/prometheus/busybox:latest").build();
+        MetricsCollector collector2 = mcBuilder.withScraperPodImage("quay.io/curl/curl-base:latest").build();
 
         // Collect metrics
         assertDoesNotThrow(() -> collector2.collectMetricsFromPods(30000)); // timeout in milliseconds

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
@@ -86,7 +86,7 @@ public final class MetricsCollectorIT extends AbstractIT {
         // Create metrics collector
         MetricsCollector collector = new MetricsCollector.Builder()
             .withNamespaceName("metrics-test")
-            .withOwnScraperPod()
+            .withDeployScraperPod()
             .withScraperPodName("test-scraper-pod")
             .withComponent(new MetricsComponent() {
                 public int getDefaultMetricsPort() {


### PR DESCRIPTION
## Description

Deploy own scraper pod.


## Type of Change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
