### PR TITLE
Change KubeCmdClient API for namespaced and custer wide commands

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
@@ -20,13 +20,6 @@ import io.skodjob.testframe.executor.ExecResult;
 public interface KubeCmdClient<K extends KubeCmdClient<K>> {
 
     /**
-     * Retrieves the default namespace for the Kubernetes client.
-     *
-     * @return The default namespace.
-     */
-    String defaultNamespace();
-
-    /**
      * Retrieves the default OLM (Operator Lifecycle Manager) namespace for the Kubernetes client.
      *
      * @return The default OLM namespace.
@@ -120,22 +113,6 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     K replace(File... files);
 
     /**
-     * Applies resource content within the current namespace.
-     *
-     * @param yamlContent The YAML content representing the resources.
-     * @return This kube client.
-     */
-    K applyContentInNamespace(String yamlContent);
-
-    /**
-     * Deletes resource content within the current namespace.
-     *
-     * @param yamlContent The YAML content representing the resources to delete.
-     * @return This kube client.
-     */
-    K deleteContentInNamespace(String yamlContent);
-
-    /**
      * Applies resource content.
      *
      * @param yamlContent The YAML content representing the resources.
@@ -185,23 +162,6 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      * @return The execution result.
      */
     ExecResult execInPod(String pod, String... command);
-
-    /**
-     * Executes a command within the current namespace.
-     *
-     * @param commands The commands to execute.
-     * @return The execution result.
-     */
-    ExecResult execInCurrentNamespace(String... commands);
-
-    /**
-     * Executes a command within the current namespace with logging to output control.
-     *
-     * @param logToOutput Determines if the output should be logged.
-     * @param commands    The commands to execute.
-     * @return The execution result.
-     */
-    ExecResult execInCurrentNamespace(boolean logToOutput, String... commands);
 
     /**
      * Executes a command within a pod container.
@@ -287,14 +247,6 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     List<String> list(String resourceType);
 
     /**
-     * Retrieves a list of cluster wide resources by type.
-     *
-     * @param resourceType The type of the resources.
-     * @return The list of resources.
-     */
-    List<String> listClusterWide(String resourceType);
-
-    /**
      * Retrieves the YAML content of a resource by type and name.
      *
      * @param resourceType The type of the resource.
@@ -310,23 +262,6 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      * @return The YAML content of the resources.
      */
     String getResourcesAsYaml(String resourceType);
-
-    /**
-     * Retrieves the YAML content of a cluster wide resource by type and name.
-     *
-     * @param resourceType The type of the resource.
-     * @param resourceName The name of the resource.
-     * @return The YAML content of the resource.
-     */
-    String getClusterWideResourceAsYaml(String resourceType, String resourceName);
-
-    /**
-     * Retrieves the YAML content of cluster wide resources by type.
-     *
-     * @param resourceType The type of the resources.
-     * @return The YAML content of the resources.
-     */
-    String getClusterWideResourcesAsYaml(String resourceType);
 
     /**
      * Creates a resource from a template and applies it.

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Kubectl.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Kubectl.java
@@ -57,16 +57,6 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
     }
 
     /**
-     * Gets the default namespace.
-     *
-     * @return The default namespace.
-     */
-    @Override
-    public String defaultNamespace() {
-        return "default";
-    }
-
-    /**
      * Gets the default OLM (Operator Lifecycle Manager) namespace.
      *
      * @return The default OLM namespace.

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Oc.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Oc.java
@@ -41,16 +41,6 @@ public class Oc extends BaseCmdKubeClient<Oc> {
     }
 
     /**
-     * Gets the default namespace.
-     *
-     * @return The default namespace.
-     */
-    @Override
-    public String defaultNamespace() {
-        return "myproject";
-    }
-
-    /**
      * Gets the default OLM (Operator Lifecycle Manager) namespace.
      *
      * @return The default OLM namespace.
@@ -103,7 +93,7 @@ public class Oc extends BaseCmdKubeClient<Oc> {
      * @return The Oc instance.
      */
     public Oc newApp(String template, Map<String, String> params) {
-        List<String> cmd = namespacedCommand("new-app", template);
+        List<String> cmd = command("new-app", template);
         for (Map.Entry<String, String> entry : params.entrySet()) {
             cmd.add("-p");
             cmd.add(entry.getKey() + "=" + entry.getValue());

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollector.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollector.java
@@ -191,7 +191,7 @@ public class LogCollector {
             } else {
                 String yaml = executeCollectionCall(
                     String.format("collect descriptions of type: %s", resourceType),
-                    () -> kubeCmdClient.getClusterWideResourcesAsYaml(resourceType)
+                    () -> kubeCmdClient.getResourcesAsYaml(resourceType)
                 );
                 String resFileName = LogCollectorUtils.getYamlFileNameForResource(resourceType);
                 String filePath = LogCollectorUtils
@@ -305,14 +305,14 @@ public class LogCollector {
      * @param resourceType          resource kind for collect
      */
     private void collectClusterWideResourcesPerFile(String clusterWideFolderPath, String resourceType) {
-        List<String> resources = kubeCmdClient.listClusterWide(resourceType);
+        List<String> resources = kubeCmdClient.list(resourceType);
         if (resources != null && !resources.isEmpty()) {
             String fullFolderPath = createResourceDirectoryInNamespaceDir(clusterWideFolderPath, resourceType);
 
             resources.forEach(resourceName -> {
                 String yaml = executeCollectionCall(
                     String.format("collect YAML description for %s:%s", resourceType, resourceName),
-                    () -> kubeCmdClient.getClusterWideResourceAsYaml(resourceType, resourceName)
+                    () -> kubeCmdClient.getResourceAsYaml(resourceType, resourceName)
                 );
 
                 String resFileName = LogCollectorUtils.getYamlFileNameForResource(resourceName);


### PR DESCRIPTION
## Description

Changes for KubeCmdClient API wiith namespaced and cluster wide comands. 
Old behavior caused confuses with commands like execInCurrentNamespace etc.. so there is a change to use it similar like f8 API
So in new way if use call `cmdCli.inNamespace("ns").list(...` call commands with `--namespace ns` but when user uses `cmdCli.list...` it call command without `--namespace` arg


## Type of Change

Please delete options that are not relevant.

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
