### PR TITLE
Rename GlobalLogCollector to MustGather and use only one callback

### DIFF
--- a/test-frame-log-collector/README.md
+++ b/test-frame-log-collector/README.md
@@ -177,25 +177,25 @@ Register `GlobalLogCollector` handlers and configure
 
 ```java
 import io.skodjob.testframe.LogCollectorBuilder;
-import io.skodjob.testframe.annotations.CollectLogs;
-import io.skodjob.testframe.listeners.GlobalLogCollector;
+import io.skodjob.testframe.annotations.MustGather;
+import io.skodjob.testframe.listeners.MustGatherController;
 import io.skodjob.testframe.resources.KubeResourceManager;
 import org.junit.jupiter.api.Test;
 
-@CollectLogs
+@MustGather
 class TestClass() {
     static {
         // Setup global log collector and handlers
-        GlobalLogCollector.setupGlobalLogCollector(new LogCollectorBuilder()
+        MustGatherController.setupGlobalLogCollector(new LogCollectorBuilder()
             .withNamespacedResources("sa", "deployment", "configmaps", "secret")
             .withClusterWideResources("nodes")
             .withKubeClient(KubeResourceManager.getKubeClient())
             .withKubeCmdClient(KubeResourceManager.getKubeCmdClient())
             .withRootFolderPath("/some-path/path/")
             .build());
-        GlobalLogCollector.addLogCallback(() -> {
-            GlobalLogCollector.getGlobalLogCollector().collectFromNamespaces("test-namespace", "test-namespace-2");
-            GlobalLogCollector.getGlobalLogCollector().collectClusterWideResources();
+        MustGatherController.setLogCallback(() -> {
+            MustGatherController.getGlobalLogCollector().collectFromNamespaces("test-namespace", "test-namespace-2");
+            MustGatherController.getGlobalLogCollector().collectClusterWideResources();
         });
     }
 

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/annotations/MustGather.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/annotations/MustGather.java
@@ -4,7 +4,7 @@
  */
 package io.skodjob.testframe.annotations;
 
-import io.skodjob.testframe.listeners.GlobalLogCollector;
+import io.skodjob.testframe.listeners.MustGatherController;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.annotation.ElementType;
@@ -19,11 +19,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * when test of prepare and post phase fails in JUnit tests.
  * It is applied at the class level.
  * <p>
- * It uses the {@link GlobalLogCollector}
+ * It uses the {@link MustGatherController}
  */
 @Target(ElementType.TYPE)
 @Retention(RUNTIME)
 @Inherited
-@ExtendWith(GlobalLogCollector.class)
-public @interface CollectLogs {
+@ExtendWith(MustGatherController.class)
+public @interface MustGather {
 }

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/AbstractIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/AbstractIT.java
@@ -5,8 +5,8 @@
 package io.skodjob.testframe.test.integration;
 
 import io.skodjob.testframe.LogCollectorBuilder;
-import io.skodjob.testframe.annotations.CollectLogs;
-import io.skodjob.testframe.listeners.GlobalLogCollector;
+import io.skodjob.testframe.annotations.MustGather;
+import io.skodjob.testframe.listeners.MustGatherController;
 import io.skodjob.testframe.test.integration.helpers.GlobalLogCollectorTestHandler;
 import io.skodjob.testframe.utils.LoggerUtils;
 import io.skodjob.testframe.annotations.ResourceManager;
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @ExtendWith(GlobalLogCollectorTestHandler.class) // For testing purpose
 @ResourceManager
-@CollectLogs
+@MustGather
 @TestVisualSeparator
 public abstract class AbstractIT {
     static AtomicBoolean isCreateHandlerCalled = new AtomicBoolean(false);
@@ -60,16 +60,16 @@ public abstract class AbstractIT {
         });
 
         // Setup global log collector and handlers
-        GlobalLogCollector.setupGlobalLogCollector(new LogCollectorBuilder()
+        MustGatherController.setupGlobalLogCollector(new LogCollectorBuilder()
             .withNamespacedResources("sa", "deployment", "configmaps", "secret")
             .withClusterWideResources("nodes")
             .withKubeClient(KubeResourceManager.getKubeClient())
             .withKubeCmdClient(KubeResourceManager.getKubeCmdClient())
             .withRootFolderPath(LOG_DIR.toString())
             .build());
-        GlobalLogCollector.addLogCallback(() -> {
-            GlobalLogCollector.getGlobalLogCollector().collectFromNamespaces("default");
-            GlobalLogCollector.getGlobalLogCollector().collectClusterWideResources();
+        MustGatherController.setLogCallback(() -> {
+            MustGatherController.getGlobalLogCollector().collectFromNamespaces("default");
+            MustGatherController.getGlobalLogCollector().collectClusterWideResources();
         });
     }
 

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MustGatherControllerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MustGatherControllerIT.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class GlobalLogCollectorIT extends AbstractIT {
+public class MustGatherControllerIT extends AbstractIT {
     @Test
     void testGlobalLogCollector() {
         fail("Expected issue");


### PR DESCRIPTION
## Description

GlobalLogCollector name is weird so we decided to rename it to MustGather


## Type of Change

Please delete options that are not relevant.

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
