### PR TITLE
Use log4j2 and slf4j properly, add maven-dependency plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <fabric8.version>6.13.1</fabric8.version>
-        <log4j.version>2.17.2</log4j.version>
+        <log4j.version>2.23.1</log4j.version>
         <slf4j.version>2.0.13</slf4j.version>
 
         <!--  TEST dependencies  -->
@@ -85,6 +85,7 @@
         <spotbugs.version>4.8.6</spotbugs.version>
         <maven.spotbugs.version>4.8.6.2</maven.spotbugs.version>
         <maven.checkstyle.version>3.4.0</maven.checkstyle.version>
+        <maven.dependency.version>3.3.0</maven.dependency.version>
 
         <maven.compile.plugin.version>3.13.0</maven.compile.plugin.version>
         <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
@@ -189,7 +190,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
@@ -289,6 +290,45 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <prependGroupId>true</prependGroupId>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>set-classpath</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <outputProperty>project.dist.classpath</outputProperty>
+                            <attach>false</attach>
+                            <prefix>lib</prefix>
+                            <prependGroupId>true</prependGroupId>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/test-frame-common/pom.xml
+++ b/test-frame-common/pom.xml
@@ -71,19 +71,27 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>openshift-client</artifactId>
+            <artifactId>kubernetes-model-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-client</artifactId>
+            <artifactId>kubernetes-model-extensions</artifactId>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
+            <artifactId>kubernetes-model-apps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-model-operatorhub</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-commons</artifactId>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -94,18 +102,59 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
         <!-- Logger -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven.dependency.version}</version>
+                    <executions>
+                        <execution>
+                            <id>analyze</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <failOnWarning>true</failOnWarning>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <!-- Needed for logging in tests used by test-frame (uses SLF4J) -->
+                                    <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/KubeClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/KubeClient.java
@@ -26,15 +26,15 @@ import io.skodjob.testframe.utils.LoggerUtils;
 import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.TestFrameEnv;
 import io.skodjob.testframe.executor.Exec;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides functionality to interact with Kubernetes and OpenShift clusters.
  * This includes creating clients, reading resources from files, and managing kubeconfig for authentication.
  */
 public class KubeClient {
-    private static final Logger LOGGER = LogManager.getLogger(KubeClient.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KubeClient.class);
 
 
     private KubernetesClient client;

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClient.java
@@ -19,8 +19,8 @@ import java.util.stream.Collectors;
 import io.skodjob.testframe.clients.KubeClusterException;
 import io.skodjob.testframe.executor.Exec;
 import io.skodjob.testframe.executor.ExecResult;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.lang.String.join;
 import static java.util.Arrays.asList;
@@ -32,7 +32,7 @@ import static java.util.Arrays.asList;
  */
 public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implements KubeCmdClient<K> {
 
-    private static final Logger LOGGER = LogManager.getLogger(BaseCmdKubeClient.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseCmdKubeClient.class);
 
     private static final String CREATE = "create";
     private static final String APPLY = "apply";

--- a/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.skodjob.testframe.utils.LoggerUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +28,7 @@ import java.util.function.Function;
  */
 public class TestEnvironmentVariables {
 
-    private static final Logger LOGGER = LogManager.getLogger(TestEnvironmentVariables.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestEnvironmentVariables.class);
 
     /* test */ private final Map<String, String> envMap;
     private Map<String, String> values = new HashMap<>();

--- a/test-frame-common/src/main/java/io/skodjob/testframe/executor/Exec.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/executor/Exec.java
@@ -30,8 +30,8 @@ import java.util.regex.Pattern;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.skodjob.testframe.clients.KubeClusterException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.lang.String.join;
 
@@ -40,7 +40,7 @@ import static java.lang.String.join;
  */
 public class Exec {
 
-    private static final Logger LOGGER = LogManager.getLogger(Exec.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Exec.class);
 
     private static final Pattern ERROR_PATTERN = Pattern.compile("Error from server \\(([a-zA-Z0-9]+)\\):");
     private static final Pattern INVALID_PATTERN = Pattern

--- a/test-frame-common/src/main/java/io/skodjob/testframe/listeners/TestVisualSeparatorExtension.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/listeners/TestVisualSeparatorExtension.java
@@ -5,17 +5,17 @@
 package io.skodjob.testframe.listeners;
 
 import io.skodjob.testframe.utils.LoggerUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * jUnit5 specific class which listening on test callbacks
  */
 public class TestVisualSeparatorExtension implements BeforeEachCallback, AfterEachCallback {
-    private final Logger logger = LogManager.getLogger(TestVisualSeparatorExtension.class);
+    private final Logger logger = LoggerFactory.getLogger(TestVisualSeparatorExtension.class);
 
     private TestVisualSeparatorExtension() {
         // Private constructor to prevent instantiation

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -33,10 +33,10 @@ import io.skodjob.testframe.clients.cmdClient.Oc;
 import io.skodjob.testframe.interfaces.NamespacedResourceType;
 import io.skodjob.testframe.interfaces.ResourceType;
 import io.skodjob.testframe.wait.Wait;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Manages Kubernetes resources for testing purposes.
  */
 public class KubeResourceManager {
-    private static final Logger LOGGER = LogManager.getLogger(KubeResourceManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KubeResourceManager.class);
 
     private static KubeResourceManager instance;
     private static KubeClient client;
@@ -197,12 +197,12 @@ public class KubeResourceManager {
     /**
      * Logs all managed resources across all test contexts with set log level
      *
-     * @param logLevel log4j2 log level
+     * @param logLevel slf4j log level event
      */
     public void printAllResources(Level logLevel) {
-        LOGGER.log(logLevel, "Printing all managed resources from all test contexts");
+        LOGGER.atLevel(logLevel).log("Printing all managed resources from all test contexts");
         STORED_RESOURCES.forEach((testName, resources) -> {
-            LOGGER.log(logLevel, "Context: {}", testName);
+            LOGGER.atLevel(logLevel).log("Context: {}", testName);
             resources.forEach(resourceItem -> {
                 if (resourceItem.resource() != null) {
                     LoggerUtils.logResource("Managed resource:", logLevel, resourceItem.resource());
@@ -214,10 +214,10 @@ public class KubeResourceManager {
     /**
      * Logs all managed resources in current test context with set log level
      *
-     * @param logLevel log4j2 log level
+     * @param logLevel slf4j log level event
      */
     public void printCurrentResources(Level logLevel) {
-        LOGGER.log(logLevel, "Printing all managed resources from current test context");
+        LOGGER.atLevel(logLevel).log("Printing all managed resources from current test context");
         STORED_RESOURCES.get(getTestContext().getDisplayName()).forEach(resourceItem -> {
             if (resourceItem.resource() != null) {
                 LoggerUtils.logResource("Managed resource:", logLevel, resourceItem.resource());

--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/ImageUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/ImageUtils.java
@@ -4,8 +4,8 @@
  */
 package io.skodjob.testframe.utils;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
  * Class containing methods for handling images
  */
 public final class ImageUtils {
-    private static final Logger LOGGER = LogManager.getLogger(ImageUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageUtils.class);
 
     private ImageUtils() {
         // Private constructor to prevent instantiation

--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/KubeUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/KubeUtils.java
@@ -11,15 +11,15 @@ import io.fabric8.openshift.api.model.operatorhub.v1alpha1.InstallPlanBuilder;
 import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.resources.KubeResourceManager;
 import io.skodjob.testframe.wait.Wait;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility methods for Kubernetes and Openshift clusters.
  */
 public final class KubeUtils {
 
-    private static final Logger LOGGER = LogManager.getLogger(KubeUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KubeUtils.class);
 
     private KubeUtils() {
         // Private constructor to prevent instantiation

--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/LoggerUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/LoggerUtils.java
@@ -7,16 +7,16 @@ package io.skodjob.testframe.utils;
 import java.util.Collections;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * Utility methods for logging.
  */
 public final class LoggerUtils {
 
-    private static final Logger LOGGER = LogManager.getLogger(LoggerUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggerUtils.class);
     static final String SEPARATOR_CHAR = "#";
 
     /**
@@ -71,11 +71,11 @@ public final class LoggerUtils {
      */
     public static <T extends HasMetadata> void logResource(String operation, Level logLevel, T resource) {
         if (resource.getMetadata().getNamespace() == null) {
-            LOGGER.log(logLevel, LoggerUtils.RESOURCE_LOGGER_PATTERN,
+            LOGGER.atLevel(logLevel).log(LoggerUtils.RESOURCE_LOGGER_PATTERN,
                 operation, resource.getKind(),
                 resource.getMetadata().getName());
         } else {
-            LOGGER.log(logLevel, LoggerUtils.RESOURCE_WITH_NAMESPACE_LOGGER_PATTERN,
+            LOGGER.atLevel(logLevel).log(LoggerUtils.RESOURCE_WITH_NAMESPACE_LOGGER_PATTERN,
                 operation,
                 resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace());
         }

--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/PodUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/PodUtils.java
@@ -11,8 +11,8 @@ import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.resources.KubeResourceManager;
 import io.skodjob.testframe.wait.Wait;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
  */
 public final class PodUtils {
 
-    private static final Logger LOGGER = LogManager.getLogger(PodUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PodUtils.class);
     private static final long READINESS_TIMEOUT = Duration.ofMinutes(10).toMillis();
 
     private PodUtils() {

--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/TestFrameUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/TestFrameUtils.java
@@ -13,8 +13,8 @@ import java.util.concurrent.TimeUnit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility methods for TestFrame.
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.Logger;
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public final class TestFrameUtils {
 
-    private static final Logger LOGGER = LogManager.getLogger(TestFrameUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestFrameUtils.class);
 
     /**
      * Default timeout for asynchronous tests.

--- a/test-frame-common/src/main/java/io/skodjob/testframe/wait/Wait.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/wait/Wait.java
@@ -4,6 +4,9 @@
  */
 package io.skodjob.testframe.wait;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
@@ -16,14 +19,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 /**
  * Wait utils
  */
 public class Wait {
-    private static final Logger LOGGER = LogManager.getLogger(Wait.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Wait.class);
 
     private Wait() {
         // Private constructor to prevent instantiation

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
@@ -102,7 +102,8 @@ public class KubeResourceManagerTest {
         testAppender.start();
 
         // print resources
-        KubeResourceManager.getInstance().printCurrentResources(Level.INFO);
+        KubeResourceManager.getInstance().printCurrentResources(org.slf4j.event.Level.INFO);
+        System.out.println(testAppender.getLogEvents());
         List<LogEvent> events = testAppender.getLogEvents();
 
         assertEquals(3, events.size());
@@ -113,7 +114,7 @@ public class KubeResourceManagerTest {
         testAppender.clean();
 
         // print all resources on debug output
-        KubeResourceManager.getInstance().printAllResources(Level.DEBUG);
+        KubeResourceManager.getInstance().printAllResources(org.slf4j.event.Level.DEBUG);
         events = testAppender.getLogEvents();
 
         assertEquals(4, events.size());

--- a/test-frame-kubernetes/pom.xml
+++ b/test-frame-kubernetes/pom.xml
@@ -71,9 +71,66 @@
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-admissionregistration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apiextensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-rbac</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-batch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-coordination</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-networking</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-common</artifactId>
         </dependency>
     </dependencies>
-
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven.dependency.version}</version>
+                    <executions>
+                        <execution>
+                            <id>analyze</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <failOnWarning>true</failOnWarning>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <!-- Needed for logging in tests used by test-frame (uses SLF4J) -->
+                                    <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/test-frame-log-collector/pom.xml
+++ b/test-frame-log-collector/pom.xml
@@ -78,21 +78,18 @@
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-common</artifactId>
         </dependency>
         <!-- Logger -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -104,8 +101,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -113,10 +115,32 @@
             <artifactId>kubernetes-server-mock</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven.dependency.version}</version>
+                    <executions>
+                        <execution>
+                            <id>analyze</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <failOnWarning>true</failOnWarning>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <!-- Needed for logging in tests used by test-frame (uses SLF4J) -->
+                                    <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-server-mock</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollector.java
+++ b/test-frame-log-collector/src/main/java/io/skodjob/testframe/LogCollector.java
@@ -10,8 +10,8 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.skodjob.testframe.clients.KubeClient;
 import io.skodjob.testframe.clients.cmdClient.KubeCmdClient;
 import io.skodjob.testframe.clients.cmdClient.Kubectl;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +27,7 @@ import java.util.function.Supplier;
  * LogCollector class containing all methods used for logs and YAML collection.
  */
 public class LogCollector {
-    private static final Logger LOGGER = LogManager.getLogger(LogCollector.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogCollector.class);
     protected final List<String> namespacedResources;
     protected final List<String> clusterWideResources;
     protected String rootFolderPath;

--- a/test-frame-metrics-collector/pom.xml
+++ b/test-frame-metrics-collector/pom.xml
@@ -76,28 +76,31 @@
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-common</artifactId>
         </dependency>
-
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -106,4 +109,31 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven.dependency.version}</version>
+                    <executions>
+                        <execution>
+                            <id>analyze</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <failOnWarning>true</failOnWarning>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <!-- Needed for logging in tests used by test-frame (uses SLF4J) -->
+                                    <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-server-mock</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -17,8 +17,8 @@ import io.skodjob.testframe.metrics.PrometheusTextFormatParser;
 import io.skodjob.testframe.resources.KubeResourceManager;
 import io.skodjob.testframe.wait.Wait;
 import io.skodjob.testframe.wait.WaitException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.security.InvalidParameterException;
@@ -51,7 +51,7 @@ import java.util.concurrent.ExecutionException;
  */
 public class MetricsCollector {
 
-    private static final Logger LOGGER = LogManager.getLogger(MetricsCollector.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetricsCollector.class);
     private static final long EXEC_TIMEOUT_MS_DEFAULT = Duration.ofSeconds(20).toMillis();
 
     protected String namespaceName;

--- a/test-frame-openshift/pom.xml
+++ b/test-frame-openshift/pom.xml
@@ -74,5 +74,43 @@
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-client-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-model-operatorhub</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client-api</artifactId>
+        </dependency>
     </dependencies>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven.dependency.version}</version>
+                    <executions>
+                        <execution>
+                            <id>analyze</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <failOnWarning>true</failOnWarning>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <!-- Needed for logging in tests used by test-frame (uses SLF4J) -->
+                                    <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/test-frame-test-examples/pom.xml
+++ b/test-frame-test-examples/pom.xml
@@ -95,7 +95,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>io.skodjob</groupId>

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
@@ -8,12 +8,12 @@ import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.testframe.clients.KubeClusterException;
 import io.skodjob.testframe.resources.KubeResourceManager;
-import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.event.Level;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;


### PR DESCRIPTION
## Description

This PR use slf4j properly in our implementation. It will now allows to users to specify their own logger implementation. In the tests we use log4j-slf4j2-impl.

I also added maven-dependency-plugin to remove unneeded dependencies

## Type of Change

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
