### PR TITLE
KubeResoruceManager: Add methods for create/update bunch resoruces and wait for all on the end

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -271,7 +271,7 @@ public class KubeResourceManager {
     }
 
     /**
-     * Creates or resources.
+     * Creates resources and wait on the end for all readiness.
      *
      * @param resources The resources to create.
      * @param <T>       The type of the resources.
@@ -282,7 +282,7 @@ public class KubeResourceManager {
     }
 
     /**
-     * Creates or updates resources.
+     * Creates or updates resources and wait on the end for all readiness.
      *
      * @param resources The resources to create.
      * @param <T>       The type of the resources.

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
@@ -4,6 +4,7 @@
  */
 package io.skodjob.testframe.test.integration;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.testframe.clients.KubeClusterException;
@@ -14,6 +15,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.slf4j.event.Level;
+
+import java.io.IOException;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -66,5 +70,12 @@ public final class KubeResourceManagerCleanerIT extends AbstractIT {
         assertNotNull(KubeResourceManager.getKubeCmdClient().get("namespace", nsName2));
         assertThrows(KubeClusterException.class, () ->
             KubeResourceManager.getKubeCmdClient().get("namespace", nsName3));
+    }
+
+    @Test
+    void testCreateMultipleResourcesAsync() throws IOException {
+        List<HasMetadata> resources = KubeResourceManager.getKubeClient()
+            .readResourcesFromFile(getClass().getClassLoader().getResourceAsStream("metrics-example.yaml"));
+        KubeResourceManager.getInstance().createOrUpdateResourceAsyncWait(resources.toArray(new HasMetadata[0]));
     }
 }

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
@@ -31,7 +31,7 @@ public final class MetricsCollectorIT extends AbstractIT {
         List<HasMetadata> resources = KubeResourceManager.getKubeClient()
             .readResourcesFromFile(getClass().getClassLoader().getResourceAsStream("metrics-example.yaml"));
 
-        KubeResourceManager.getInstance().createResourceWithWait(resources.toArray(new HasMetadata[0]));
+        KubeResourceManager.getInstance().createResourceAsyncWait(resources.toArray(new HasMetadata[0]));
 
         // Check deployment is not null
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("metrics-test").get());


### PR DESCRIPTION
## Description

Implement 2 new methods in KubeResoruceManager for creating bunch of resources and wait for condition in batch on the end.
This speedup deployments of bunch resources.


## Type of Change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
