### PR TITLE
Remove unnecesary String.format methods in logger

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/listeners/TestVisualSeparatorExtension.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/listeners/TestVisualSeparatorExtension.java
@@ -24,14 +24,14 @@ public class TestVisualSeparatorExtension implements BeforeEachCallback, AfterEa
     @Override
     public void beforeEach(ExtensionContext extensionContext) {
         LoggerUtils.logSeparator();
-        logger.info(String.format("%s.%s-STARTED", extensionContext.getRequiredTestClass().getName(),
-            extensionContext.getDisplayName().replace("()", "")));
+        logger.info("{}.{}-STARTED", extensionContext.getRequiredTestClass().getName(),
+            extensionContext.getDisplayName().replace("()", ""));
     }
 
     @Override
     public void afterEach(ExtensionContext extensionContext) {
-        logger.info(String.format("%s.%s-FINISHED", extensionContext.getRequiredTestClass().getName(),
-            extensionContext.getDisplayName().replace("()", "")));
+        logger.info("{}.{}-FINISHED", extensionContext.getRequiredTestClass().getName(),
+            extensionContext.getDisplayName().replace("()", ""));
         LoggerUtils.logSeparator();
     }
 }


### PR DESCRIPTION
## Description

Remove string format method from logger methods


## Type of Change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
