### PR TITLE
Delete wait async batch

### DIFF
--- a/test-frame-common/src/main/resources/log4j2.properties
+++ b/test-frame-common/src/main/resources/log4j2.properties
@@ -3,7 +3,7 @@ name = TFConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highlight{%-5p} [%c{1}:%L] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%tid] %highlight{%-5p} [%c{1}:%L] %m%n
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile

--- a/test-frame-log-collector/src/main/resources/log4j2.properties
+++ b/test-frame-log-collector/src/main/resources/log4j2.properties
@@ -3,7 +3,7 @@ name = LCConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highlight{%-5p} [%c{1}:%L] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%tid] %highlight{%-5p} [%c{1}:%L] %m%n
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile

--- a/test-frame-metrics-collector/src/main/resources/log4j2.properties
+++ b/test-frame-metrics-collector/src/main/resources/log4j2.properties
@@ -3,7 +3,7 @@ name = MCConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%thread] %highlight{%-5p} [%c{1}:%L] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss}{GMT} [%tid] %highlight{%-5p} [%c{1}:%L] %m%n
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile


### PR DESCRIPTION
## Description

Wait async when deletion resources.

During experiments with streams-e2e I was able to save more then `3min` (per test) when I had to delete all operators etc...

I also changed log4j2.properties to log thread ID instead of name to do not mess log output.

## Type of Change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
