### PR TITLE
Add getValue() method to Counter type metric

### DIFF
--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Counter.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Counter.java
@@ -25,6 +25,15 @@ public class Counter extends Metric {
     }
 
     /**
+     * Returns value
+     *
+     * @return value
+     */
+    public double getValue() {
+        return value;
+    }
+
+    /**
      * Metric string representation
      *
      * @return string representation


### PR DESCRIPTION
## Description

The `Counter` metric type is the only one missing the `getValue()` method, which is used for obtaining the `value` parameter from the Counter object.
This PR adds it to the code.

## Type of Change

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit/integration tests pass locally with my changes
