### PR TITLE
Add original metric in String to the Metric object

### DIFF
--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Counter.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Counter.java
@@ -46,6 +46,7 @@ public class Counter extends Metric {
             ", labels=" + labels +
             ", value=" + value +
             ", type=" + type +
+            ", stringMetric=" + stringMetric +
             '}';
     }
 }

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Counter.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Counter.java
@@ -15,12 +15,13 @@ public class Counter extends Metric {
     /**
      * Constructor
      *
-     * @param name   name of metric
-     * @param labels labels
-     * @param value  value
+     * @param name          name of metric
+     * @param labels        labels
+     * @param value         value
+     * @param stringMetric  original (not parsed) metric in String
      */
-    public Counter(String name, Map<String, String> labels, double value) {
-        super(name, labels, MetricType.COUNTER);
+    public Counter(String name, Map<String, String> labels, String stringMetric, double value) {
+        super(name, labels, MetricType.COUNTER, stringMetric);
         this.value = value;
     }
 

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Gauge.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Gauge.java
@@ -46,6 +46,7 @@ public class Gauge extends Metric {
             ", labels=" + labels +
             ", value=" + value +
             ", type=" + type +
+            ", stringMetric=" + stringMetric +
             '}';
     }
 }

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Gauge.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Gauge.java
@@ -15,12 +15,13 @@ public class Gauge extends Metric {
     /**
      * Constructor
      *
-     * @param name   name of metric
-     * @param labels labels
-     * @param value  value
+     * @param name          name of metric
+     * @param labels        labels
+     * @param value         value
+     * @param stringMetric  original (not parsed) metric in String
      */
-    public Gauge(String name, Map<String, String> labels, double value) {
-        super(name, labels, MetricType.GAUGE);
+    public Gauge(String name, Map<String, String> labels, String stringMetric, double value) {
+        super(name, labels, MetricType.GAUGE, stringMetric);
         this.value = value;
     }
 

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Histogram.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Histogram.java
@@ -18,11 +18,12 @@ public class Histogram extends Metric {
     /**
      * Constructor
      *
-     * @param name   name of metric
-     * @param labels labels
+     * @param name          name of metric
+     * @param labels        labels
+     * @param stringMetric  original (not parsed) metric in String
      */
-    public Histogram(String name, Map<String, String> labels) {
-        super(name, labels, MetricType.HISTOGRAM);
+    public Histogram(String name, Map<String, String> labels, String stringMetric) {
+        super(name, labels, MetricType.HISTOGRAM, stringMetric);
     }
 
     /**

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Histogram.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Histogram.java
@@ -95,6 +95,7 @@ public class Histogram extends Metric {
             ", sum=" + sum +
             ", count=" + count +
             ", type=" + type +
+            ", stringMetric=" + stringMetric +
             '}';
     }
 }

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Metric.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Metric.java
@@ -13,18 +13,21 @@ public abstract class Metric {
     String name;
     Map<String, String> labels;
     MetricType type;
+    String stringMetric;
 
     /**
      * constructor
      *
-     * @param name   name of metric
-     * @param labels labels
-     * @param type   type
+     * @param name          name of metric
+     * @param labels        labels
+     * @param type          type
+     * @param stringMetric  original (not parsed) metric in String
      */
-    Metric(String name, Map<String, String> labels, MetricType type) {
+    Metric(String name, Map<String, String> labels, MetricType type, String stringMetric) {
         this.name = name;
         this.labels = labels;
         this.type = type;
+        this.stringMetric = stringMetric;
     }
 
     /**
@@ -52,6 +55,15 @@ public abstract class Metric {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Get original metric, from which was the object created.
+     *
+     * @return original metric
+     */
+    public String getStringMetric() {
+        return stringMetric;
     }
 
     /**

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Metric.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Metric.java
@@ -77,6 +77,7 @@ public abstract class Metric {
             "name='" + name + '\'' +
             ", labels=" + labels +
             ", type=" + type +
+            ", stringMetric=" + stringMetric +
             '}';
     }
 }

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/PrometheusTextFormatParser.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/PrometheusTextFormatParser.java
@@ -49,10 +49,10 @@ public class PrometheusTextFormatParser {
                 Map<String, String> labels = parseLabels(nameAndLabels[1]);
 
                 if (name.endsWith("_total")) {
-                    metrics.add(new Counter(name, labels, value));
+                    metrics.add(new Counter(name, labels, line, value));
                 } else if (name.contains("_bucket")) {
                     if (currentHistogram == null || !currentHistogram.name.equals(name)) {
-                        currentHistogram = new Histogram(name, labels);
+                        currentHistogram = new Histogram(name, labels, line);
                         metrics.add(currentHistogram);
                     }
                     double upperBound = labels.get("le").contains("+Inf") ?
@@ -72,13 +72,13 @@ public class PrometheusTextFormatParser {
                     }
                 } else if (name.contains("{quantile=")) {
                     if (currentSummary == null || !currentSummary.name.equals(name)) {
-                        currentSummary = new Summary(name, labels);
+                        currentSummary = new Summary(name, labels, line);
                         metrics.add(currentSummary);
                     }
                     double quantile = Double.parseDouble(labels.get("quantile"));
                     currentSummary.addQuantile(quantile, value);
                 } else {
-                    metrics.add(new Gauge(name, labels, value));
+                    metrics.add(new Gauge(name, labels, line, value));
                 }
             }
         }

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Summary.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Summary.java
@@ -18,11 +18,12 @@ public class Summary extends Metric {
     /**
      * Constructor
      *
-     * @param name   name of metric
-     * @param labels labels
+     * @param name          name of metric
+     * @param labels        labels
+     * @param stringMetric  original (not parsed) metric in String
      */
-    public Summary(String name, Map<String, String> labels) {
-        super(name, labels, MetricType.SUMMARY);
+    public Summary(String name, Map<String, String> labels, String stringMetric) {
+        super(name, labels, MetricType.SUMMARY, stringMetric);
     }
 
     /**

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Summary.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Summary.java
@@ -95,6 +95,7 @@ public class Summary extends Metric {
             ", sum=" + sum +
             ", count=" + count +
             ", type=" + type +
+            ", stringMetric=" + stringMetric +
             '}';
     }
 }

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Untyped.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Untyped.java
@@ -15,12 +15,13 @@ public class Untyped extends Metric {
     /**
      * Constructor
      *
-     * @param name   name of metric
-     * @param labels labels
-     * @param value  value
+     * @param name          name of metric
+     * @param labels        labels
+     * @param value         value
+     * @param stringMetric  original (not parsed) metric in String
      */
-    public Untyped(String name, Map<String, String> labels, double value) {
-        super(name, labels, MetricType.UNTYPED);
+    public Untyped(String name, Map<String, String> labels, String stringMetric, double value) {
+        super(name, labels, MetricType.UNTYPED, stringMetric);
         this.value = value;
     }
 

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Untyped.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/Untyped.java
@@ -46,6 +46,7 @@ public class Untyped extends Metric {
             ", labels=" + labels +
             ", value=" + value +
             ", type=" + type +
+            ", stringMetric=" + stringMetric +
             '}';
     }
 }

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorTest.java
@@ -55,7 +55,7 @@ class MetricsCollectorTest {
         // Setup
         HashMap<String, List<Metric>> invalidData = new HashMap<>();
         invalidData.put("pod", Collections.singletonList(new Gauge("metric_name",
-            Collections.singletonMap("label", "value"), 32)));
+            Collections.singletonMap("label", "value"), "metric_name {label=value} 32", 32)));
         this.metricsCollector.setCollectedData(invalidData);
 
         // Execution
@@ -76,7 +76,7 @@ class MetricsCollectorTest {
     void testCollectMetricWithLabelsMatchingEntries() {
         HashMap<String, List<Metric>> invalidData = new HashMap<>();
         invalidData.put("pod", Collections.singletonList(new Gauge("metric_name",
-            Collections.singletonMap("label", "value"), 100)));
+            Collections.singletonMap("label", "value"), "metric_name {label=value} 100", 100)));
         this.metricsCollector.setCollectedData(invalidData);
 
         List<Metric>  results = this.metricsCollector.collectMetricWithLabels("pod", "label");


### PR DESCRIPTION
## Description

Because we are checking the existence of some metric using regexes, it would be worth having the full/original metric in String stored inside the `Metric` object.
That way we can also see from what was the particular metric object parsed.

This PR adds `stringMetric` variable to the `Metric` object, which will contain exactly this value. Because it enhances the default constructor, the constructors (and the creation of each object) had to be changed as well.

## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit/integration tests pass locally with my changes
