### PR TITLE
Bump dependencies - fabric8, javadoc, jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
 
-        <fabric8.version>6.13.4</fabric8.version>
+        <fabric8.version>7.0.0</fabric8.version>
         <log4j.version>2.24.2</log4j.version>
         <slf4j.version>2.0.16</slf4j.version>
 
@@ -92,13 +92,13 @@
         <maven.deploy.plugin.version>3.1.3</maven.deploy.plugin.version>
         <maven.gpg.version>3.2.7</maven.gpg.version>
         <sonatype.nexus.central>0.6.0</sonatype.nexus.central>
-        <maven.javadoc.version>3.11.1</maven.javadoc.version>
+        <maven.javadoc.version>3.11.2</maven.javadoc.version>
         <maven.assembly.version>3.7.1</maven.assembly.version>
         <maven.plugin.plugin.version>3.9.0</maven.plugin.plugin.version>
         <junit.jupiter.version>5.11.3</junit.jupiter.version>
         <junit.platform.version>1.11.3</junit.platform.version>
         <maven.surefire.version>3.5.2</maven.surefire.version>
-        <jackson-dataformat-yaml.version>2.18.1</jackson-dataformat-yaml.version>
+        <jackson-dataformat-yaml.version>2.18.2</jackson-dataformat-yaml.version>
         <org.eclipse.sisu.version>0.9.0.M3</org.eclipse.sisu.version>
         <bouncycastle.version>1.79</bouncycastle.version>
 

--- a/test-frame-common/pom.xml
+++ b/test-frame-common/pom.xml
@@ -63,6 +63,10 @@
     <dependencies>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>
@@ -157,6 +161,8 @@
                                 <ignoredUnusedDeclaredDependencies>
                                     <!-- Needed for logging in tests used by test-frame (uses SLF4J) -->
                                     <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
+                                    <!-- Needed for importing KubernetesClientImpl -->
+                                    <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-client</ignoredUnusedDeclaredDependency>
                                 </ignoredUnusedDeclaredDependencies>
                             </configuration>
                         </execution>

--- a/test-frame-test-examples/pom.xml
+++ b/test-frame-test-examples/pom.xml
@@ -43,10 +43,6 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-model</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>generator-annotations</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Description

Bumps the dependencies group with 3 updates: [io.fabric8:kubernetes-client-bom-with-deps](https://github.com/fabric8io/kubernetes-client), [com.fasterxml.jackson.dataformat:jackson-dataformat-yaml](https://github.com/FasterXML/jackson-dataformats-text) and [org.apache.maven.plugins:maven-javadoc-plugin](https://github.com/apache/maven-javadoc-plugin).

Updates io.fabric8:kubernetes-client-bom-with-deps from 6.13.4 to 7.0.0

## Type of Change

* Update (Update version or update existing automation)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
