### PR TITLE
Change KubeResourceManager API

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ class Test {
 class Test {
     @Test
     void testMethod() {
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
                 new NamespaceBuilder().withNewMetadata().withName("test").endMetadata().build());
         assertNotNull(KubeResourceManager.getKubeCmdClient().get("namespace", "test"));
     }
@@ -79,7 +79,7 @@ class Test {
 ```
 ### Register `ResourceType` or `NamespacedResourceType` classes into `KubeResourceManager`
 ```java
-KubeResourceManager.getInstance().setResourceTypes(
+KubeResourceManager.get().setResourceTypes(
         new NamespaceType(),
         new JobType(),
         new NetworkPolicyType()

--- a/test-frame-common/src/main/java/io/skodjob/testframe/listeners/ResourceManagerCleanerExtension.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/listeners/ResourceManagerCleanerExtension.java
@@ -34,8 +34,8 @@ public class ResourceManagerCleanerExtension implements AfterAllCallback, AfterE
             findAnnotation(extensionContext.getRequiredTestClass(), ResourceManager.class);
 
         if (annotation.isPresent() && annotation.get().cleanResources()) {
-            KubeResourceManager.setTestContext(extensionContext);
-            KubeResourceManager.getInstance().deleteResources();
+            KubeResourceManager.get().setTestContext(extensionContext);
+            KubeResourceManager.get().deleteResources();
         }
     }
 
@@ -50,8 +50,8 @@ public class ResourceManagerCleanerExtension implements AfterAllCallback, AfterE
             findAnnotation(extensionContext.getRequiredTestClass(), ResourceManager.class);
 
         if (annotation.isPresent() && annotation.get().cleanResources()) {
-            KubeResourceManager.setTestContext(extensionContext);
-            KubeResourceManager.getInstance().deleteResources(annotation.get().asyncDeletion());
+            KubeResourceManager.get().setTestContext(extensionContext);
+            KubeResourceManager.get().deleteResources(annotation.get().asyncDeletion());
         }
     }
 }

--- a/test-frame-common/src/main/java/io/skodjob/testframe/listeners/ResourceManagerExtension.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/listeners/ResourceManagerExtension.java
@@ -18,26 +18,26 @@ public class ResourceManagerExtension
     implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback, AfterEachCallback {
 
     private ResourceManagerExtension() {
-        KubeResourceManager.getInstance();
+        KubeResourceManager.get();
     }
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
-        KubeResourceManager.setTestContext(extensionContext);
+        KubeResourceManager.get().setTestContext(extensionContext);
     }
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) {
-        KubeResourceManager.setTestContext(extensionContext);
+        KubeResourceManager.get().setTestContext(extensionContext);
     }
 
     @Override
     public void afterAll(ExtensionContext extensionContext) {
-        KubeResourceManager.setTestContext(extensionContext);
+        KubeResourceManager.get().setTestContext(extensionContext);
     }
 
     @Override
     public void afterEach(ExtensionContext extensionContext) {
-        KubeResourceManager.setTestContext(extensionContext);
+        KubeResourceManager.get().setTestContext(extensionContext);
     }
 }

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -62,7 +62,7 @@ public class KubeResourceManager {
     private static final ThreadLocal<ExtensionContext> TEST_CONTEXT = new ThreadLocal<>();
     private static final Map<String, Stack<ResourceItem<?>>> STORED_RESOURCES = new LinkedHashMap<>();
 
-    private static String storeYamlPath = null;
+    private String storeYamlPath = null;
 
     private KubeResourceManager() {
         // Private constructor to prevent instantiation
@@ -72,8 +72,20 @@ public class KubeResourceManager {
      * Retrieves the singleton instance of KubeResourceManager.
      *
      * @return The singleton instance of KubeResourceManager.
+     * @deprecated Will be removed in future release.
      */
+    @Deprecated
     public static synchronized KubeResourceManager getInstance() {
+        return get();
+    }
+
+
+    /**
+     * Retrieves the singleton instance of KubeResourceManager.
+     *
+     * @return The singleton instance of KubeResourceManager.
+     */
+    public static synchronized KubeResourceManager get() {
         if (instance == null) {
             instance = new KubeResourceManager();
             instance.resourceTypes = new ResourceType[]{};
@@ -110,7 +122,7 @@ public class KubeResourceManager {
      *
      * @param context The extension context.
      */
-    public static void setTestContext(ExtensionContext context) {
+    public void setTestContext(ExtensionContext context) {
         TEST_CONTEXT.set(context);
     }
 
@@ -119,7 +131,7 @@ public class KubeResourceManager {
      *
      * @return The extension context.
      */
-    public static ExtensionContext getTestContext() {
+    public ExtensionContext getTestContext() {
         return TEST_CONTEXT.get();
     }
 
@@ -155,7 +167,7 @@ public class KubeResourceManager {
      *
      * @param path root path for storing
      */
-    public static void setStoreYamlPath(String path) {
+    public void setStoreYamlPath(String path) {
         storeYamlPath = path;
     }
 
@@ -164,7 +176,7 @@ public class KubeResourceManager {
      *
      * @return path
      */
-    public static String getStoreYamlPath() {
+    public String getStoreYamlPath() {
         return storeYamlPath;
     }
 

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
@@ -46,27 +46,27 @@ public class KubeResourceManagerTest {
 
     @Test
     void testCreateDeleteNamespace() {
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName("test").endMetadata().build());
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test").get());
     }
 
     @Test
     void testDeleteAllResources() {
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName("test2").endMetadata().build());
         assertNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test").get());
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
-        KubeResourceManager.getInstance().deleteResources();
+        KubeResourceManager.get().deleteResources();
         assertNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
     }
 
     @Test
     void testUpdateResource() {
         Namespace ns = new NamespaceBuilder().withNewMetadata().withName("test3").endMetadata().build();
-        KubeResourceManager.getInstance().createResourceWithWait(ns);
+        KubeResourceManager.get().createResourceWithWait(ns);
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test3").get());
-        KubeResourceManager.getInstance().updateResource(ns.edit()
+        KubeResourceManager.get().updateResource(ns.edit()
             .editMetadata().addToLabels(Collections.singletonMap("test-label", "true")).endMetadata().build());
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test3").get()
             .getMetadata().getLabels().get("test-label"));
@@ -75,20 +75,20 @@ public class KubeResourceManagerTest {
     @Test
     void testCreateOrUpdateResource() {
         Namespace ns = new NamespaceBuilder().withNewMetadata().withName("test4").endMetadata().build();
-        KubeResourceManager.getInstance().createResourceWithWait(ns);
+        KubeResourceManager.get().createResourceWithWait(ns);
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test4").get());
-        KubeResourceManager.getInstance().createOrUpdateResourceWithWait(ns);
+        KubeResourceManager.get().createOrUpdateResourceWithWait(ns);
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test4").get());
-        KubeResourceManager.getInstance().createOrUpdateResourceWithoutWait(ns);
+        KubeResourceManager.get().createOrUpdateResourceWithoutWait(ns);
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test4").get());
     }
 
     @Test
     void testLoggingManagedResources() {
         // create resources
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName("test-ns").endMetadata().build());
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new ServiceAccountBuilder().withNewMetadata().withName("test-sa").endMetadata().build());
 
         // setup mock logger appender
@@ -102,7 +102,7 @@ public class KubeResourceManagerTest {
         testAppender.start();
 
         // print resources
-        KubeResourceManager.getInstance().printCurrentResources(org.slf4j.event.Level.INFO);
+        KubeResourceManager.get().printCurrentResources(org.slf4j.event.Level.INFO);
         System.out.println(testAppender.getLogEvents());
         List<LogEvent> events = testAppender.getLogEvents();
 
@@ -114,7 +114,7 @@ public class KubeResourceManagerTest {
         testAppender.clean();
 
         // print all resources on debug output
-        KubeResourceManager.getInstance().printAllResources(org.slf4j.event.Level.DEBUG);
+        KubeResourceManager.get().printAllResources(org.slf4j.event.Level.DEBUG);
         events = testAppender.getLogEvents();
 
         assertEquals(4, events.size());

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/UtilsTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/UtilsTest.java
@@ -39,9 +39,9 @@ public class UtilsTest {
 
     @Test
     void testPodUtils() {
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName("test").endMetadata().build());
-        KubeResourceManager.getInstance().createResourceWithoutWait(
+        KubeResourceManager.get().createResourceWithoutWait(
             new PodBuilder()
                 .withNewMetadata()
                     .withName("test-pod")
@@ -71,7 +71,7 @@ public class UtilsTest {
 
     @Test
     void testKubeUtils() {
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName("test").endMetadata().build());
 
         KubeUtils.labelNamespace("test", "test-label", "true");

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -207,8 +207,8 @@ public class MetricsCollector {
 
     private synchronized KubernetesClient getKubeClient() {
         if (kubeClient == null) {
-            KubeResourceManager resourceManager = KubeResourceManager.getInstance();
-            kubeClient = resourceManager.getKubeClient().getClient();
+            KubeResourceManager resourceManager = KubeResourceManager.get();
+            kubeClient = KubeResourceManager.getKubeClient().getClient();
             if (kubeClient == null) {
                 throw new IllegalStateException("KubeClient is not available");
             }
@@ -219,8 +219,8 @@ public class MetricsCollector {
 
     private synchronized KubeCmdClient<?> getKubeCmdClient() {
         if (kubeCmdClient == null) {
-            final KubeResourceManager resourceManager = KubeResourceManager.getInstance();
-            kubeCmdClient = resourceManager.getKubeCmdClient();
+            final KubeResourceManager resourceManager = KubeResourceManager.get();
+            kubeCmdClient = KubeResourceManager.getKubeCmdClient();
             if (kubeCmdClient == null) {
                 throw new IllegalStateException("KubeCmdClient is not available");
             }
@@ -411,14 +411,14 @@ public class MetricsCollector {
                 .endContainer()
             .endSpec()
             .build();
-        KubeResourceManager.getInstance().createResourceWithWait(scraperPod);
+        KubeResourceManager.get().createResourceWithWait(scraperPod);
     }
 
     /**
      * Delete own scraper pod
      */
     private void deleteScraperPod() {
-        KubeResourceManager.getInstance().deleteResource(
+        KubeResourceManager.get().deleteResource(
             new PodBuilder()
                 .withNewMetadata()
                     .withName(this.scraperPodName)

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/AbstractIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/AbstractIT.java
@@ -30,17 +30,17 @@ public abstract class AbstractIT {
 
     static {
         // Register resources which KRM uses for handling instead of native status check
-        KubeResourceManager.getInstance().setResourceTypes(
+        KubeResourceManager.get().setResourceTypes(
             new NamespaceType(),
             new ServiceAccountType(),
             new DeploymentType()
         );
 
         // Allow storing yaml files
-        KubeResourceManager.setStoreYamlPath(LOG_DIR.toString());
+        KubeResourceManager.get().setStoreYamlPath(LOG_DIR.toString());
 
         // Register callback which are called with every create resource method for every resource
-        KubeResourceManager.getInstance().addCreateCallback(r -> {
+        KubeResourceManager.get().addCreateCallback(r -> {
             isCreateHandlerCalled.set(true);
             if (r.getKind().equals("Namespace")) {
                 KubeUtils.labelNamespace(r.getMetadata().getName(), "test-label", "true");
@@ -48,7 +48,7 @@ public abstract class AbstractIT {
         });
 
         // Register callback which are called with every delete resource method for every resource
-        KubeResourceManager.getInstance().addDeleteCallback(r -> {
+        KubeResourceManager.get().addDeleteCallback(r -> {
             isDeleteHandlerCalled.set(true);
             if (r.getKind().equals("Namespace")) {
                 LoggerUtils.logResource("Deleted", r);

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeClientIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeClientIT.java
@@ -22,7 +22,7 @@ public final class KubeClientIT extends AbstractIT {
         List<HasMetadata> resources = KubeResourceManager.getKubeClient()
             .readResourcesFromFile(getClass().getClassLoader().getResourceAsStream("resources.yaml"));
 
-        KubeResourceManager.getInstance().createResourceWithWait(resources.toArray(new HasMetadata[0]));
+        KubeResourceManager.get().createResourceWithWait(resources.toArray(new HasMetadata[0]));
 
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName4).get());
         assertNotNull(KubeResourceManager.getKubeClient().getClient().serviceAccounts()

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
@@ -31,13 +31,13 @@ public final class KubeResourceManagerCleanerIT extends AbstractIT {
 
     @BeforeAll
     void setupAll() {
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName(nsName1).endMetadata().build());
     }
 
     @BeforeEach
     void setupEach() {
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName(nsName2).endMetadata().build());
     }
 
@@ -51,12 +51,12 @@ public final class KubeResourceManagerCleanerIT extends AbstractIT {
     @Test
     void createResource() {
         Namespace ns = new NamespaceBuilder().withNewMetadata().withName(nsName3).endMetadata().build();
-        KubeResourceManager.getInstance().createResourceWithWait(ns);
+        KubeResourceManager.get().createResourceWithWait(ns);
         assertTrue(isCreateHandlerCalled.get());
-        KubeResourceManager.getInstance().createOrUpdateResourceWithWait(ns);
+        KubeResourceManager.get().createOrUpdateResourceWithWait(ns);
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName3).get()
             .getMetadata().getLabels().get("test-label"));
-        KubeResourceManager.getInstance().printAllResources(Level.INFO);
+        KubeResourceManager.get().printAllResources(Level.INFO);
     }
 
     @Test
@@ -78,6 +78,6 @@ public final class KubeResourceManagerCleanerIT extends AbstractIT {
     void testCreateMultipleResourcesAsync() throws IOException {
         List<HasMetadata> resources = KubeResourceManager.getKubeClient()
             .readResourcesFromFile(getClass().getClassLoader().getResourceAsStream("metrics-example.yaml"));
-        KubeResourceManager.getInstance().createOrUpdateResourceAsyncWait(resources.toArray(new HasMetadata[0]));
+        KubeResourceManager.get().createOrUpdateResourceAsyncWait(resources.toArray(new HasMetadata[0]));
     }
 }

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
@@ -23,22 +23,22 @@ public final class KubeResourceManagerIT extends AbstractIT {
 
     @BeforeEach
     void setupEach() {
-        KubeResourceManager.getInstance().createResourceWithWait(ns1);
+        KubeResourceManager.get().createResourceWithWait(ns1);
     }
 
     @AfterEach
     void afterEach() {
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName2).get());
-        KubeResourceManager.getInstance().deleteResources();
+        KubeResourceManager.get().deleteResources();
     }
 
     @Test
     void createResource() {
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName("test2").endMetadata().build());
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName1).get());
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName2).get());
-        KubeResourceManager.getInstance().deleteResource(false, ns1);
+        KubeResourceManager.get().deleteResource(false, ns1);
         assertTrue(isDeleteHandlerCalled.get());
     }
 }

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
@@ -66,7 +66,7 @@ public class LogCollectorIT extends AbstractIT {
 
         int deploymentReplicas = 2;
 
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder()
                 .editOrNewMetadata()
                     .withName(namespaceName1)
@@ -79,7 +79,7 @@ public class LogCollectorIT extends AbstractIT {
                 .build()
         );
 
-        KubeResourceManager.getInstance().createResourceWithWait(
+        KubeResourceManager.get().createResourceWithWait(
             new DeploymentBuilder()
                 .editOrNewMetadata()
                     .withNamespace(namespaceName1)

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
@@ -31,7 +31,7 @@ public final class MetricsCollectorIT extends AbstractIT {
         List<HasMetadata> resources = KubeResourceManager.getKubeClient()
             .readResourcesFromFile(getClass().getClassLoader().getResourceAsStream("metrics-example.yaml"));
 
-        KubeResourceManager.getInstance().createResourceAsyncWait(resources.toArray(new HasMetadata[0]));
+        KubeResourceManager.get().createResourceAsyncWait(resources.toArray(new HasMetadata[0]));
 
         // Check deployment is not null
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("metrics-test").get());
@@ -77,7 +77,7 @@ public final class MetricsCollectorIT extends AbstractIT {
             .readResourcesFromFile(getClass().getClassLoader().getResourceAsStream("metrics-example.yaml"))
             .stream().filter(resource -> !resource.getMetadata().getName().equals("scraper-pod")).toList();
 
-        KubeResourceManager.getInstance().createResourceWithWait(resources.toArray(new HasMetadata[0]));
+        KubeResourceManager.get().createResourceWithWait(resources.toArray(new HasMetadata[0]));
 
         // Check deployment is not null
         assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("metrics-test").get());


### PR DESCRIPTION
## Description

Change API of KubeResoruceManager
1. deprecated getInstance() method and use instead of get() method for getting instance
2. Context set/get methods moved from static to non-static
3. YAML path configuration method moved from static to non static


## Type of Change

Please delete options that are not relevant.

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
