### PR TITLE
Fix test-frame examples on openshift

### DIFF
--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
@@ -97,7 +97,7 @@ public class LogCollectorIT extends AbstractIT {
                         .editOrNewSpec()
                             .addToContainers(new ContainerBuilder()
                                 .withName("nginx")
-                                .withImage("quay.io/jitesoft/nginx")
+                                .withImage("quay.io/nginx/nginx-unprivileged")
                                 .withPorts(new ContainerPortBuilder()
                                     .withContainerPort(80)
                                     .build())


### PR DESCRIPTION
## Description

Fix examples to run on openshift. since ocp 4.16 nginx image in test examples is supposed to run with priveledges which is not by default supported. So I have to switch to non root user image which works fine.


## Type of Change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
