### PR TITLE
Update KubeResourceManager api for kubernetes clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ class Test {
     void testMethod() {
         KubeResourceManager.get().createResourceWithWait(
                 new NamespaceBuilder().withNewMetadata().withName("test").endMetadata().build());
-        assertNotNull(KubeResourceManager.getKubeCmdClient().get("namespace", "test"));
+        assertNotNull(KubeResourceManager.get().kubeCmdClient().get("namespace", "test"));
     }
 }
 //...

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -104,7 +104,7 @@ public class KubeResourceManager {
      *
      * @return The Kubernetes client.
      */
-    public static KubeClient getKubeClient() {
+    public KubeClient kubeClient() {
         return client;
     }
 
@@ -113,7 +113,7 @@ public class KubeResourceManager {
      *
      * @return The Kubernetes command-line client.
      */
-    public static KubeCmdClient<?> getKubeCmdClient() {
+    public KubeCmdClient<?> kubeCmdClient() {
         return kubeCmdClient;
     }
 
@@ -490,7 +490,7 @@ public class KubeResourceManager {
                 condition.conditionName(), resource.getKind(), resource.getMetadata().getName()),
             TestFrameConstants.GLOBAL_POLL_INTERVAL_MEDIUM, TestFrameConstants.GLOBAL_TIMEOUT,
             () -> {
-                T res = getKubeClient().getClient().resource(resource).get();
+                T res = kubeClient().getClient().resource(resource).get();
                 resourceReady[0] = condition.predicate().test(res);
                 return resourceReady[0];
             });

--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/KubeUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/KubeUtils.java
@@ -36,7 +36,7 @@ public final class KubeUtils {
         Wait.until("InstallPlan approval", TestFrameConstants.GLOBAL_POLL_INTERVAL_SHORT, 15_000, () -> {
             try {
                 InstallPlan installPlan =
-                    new InstallPlanBuilder(KubeResourceManager.getKubeClient()
+                    new InstallPlanBuilder(KubeResourceManager.get().kubeClient()
                         .getOpenShiftClient().operatorHub().installPlans()
                         .inNamespace(namespaceName).withName(installPlanName).get())
                         .editSpec()
@@ -44,7 +44,7 @@ public final class KubeUtils {
                         .endSpec()
                         .build();
 
-                KubeResourceManager.getKubeClient().getOpenShiftClient().operatorHub().installPlans()
+                KubeResourceManager.get().kubeClient().getOpenShiftClient().operatorHub().installPlans()
                     .inNamespace(namespaceName).withName(installPlanName).patch(installPlan);
                 return true;
             } catch (Exception ex) {
@@ -62,7 +62,7 @@ public final class KubeUtils {
      * @return list of not approved install-plans
      */
     public static InstallPlan getNonApprovedInstallPlan(String namespaceName, String csvPrefix) {
-        return KubeResourceManager.getKubeClient().getOpenShiftClient().operatorHub().installPlans()
+        return KubeResourceManager.get().kubeClient().getOpenShiftClient().operatorHub().installPlans()
             .inNamespace(namespaceName).list().getItems().stream()
             .filter(installPlan -> !installPlan.getSpec().getApproved()
                 && installPlan.getSpec().getClusterServiceVersionNames().toString().contains(csvPrefix))
@@ -77,11 +77,11 @@ public final class KubeUtils {
      * @param value     label value
      */
     public static void labelNamespace(String namespace, String key, String value) {
-        if (KubeResourceManager.getKubeClient().namespaceExists(namespace)) {
+        if (KubeResourceManager.get().kubeClient().namespaceExists(namespace)) {
             Wait.until(String.format("Namespace %s has label: %s", namespace, key),
                 TestFrameConstants.GLOBAL_POLL_INTERVAL_1_SEC, TestFrameConstants.GLOBAL_STABILITY_TIME, () -> {
                     try {
-                        KubeResourceManager.getKubeClient().getClient().namespaces().withName(namespace).edit(n ->
+                        KubeResourceManager.get().kubeClient().getClient().namespaces().withName(namespace).edit(n ->
                             new NamespaceBuilder(n)
                                 .editMetadata()
                                 .addToLabels(key, value)
@@ -90,7 +90,7 @@ public final class KubeUtils {
                     } catch (Exception ex) {
                         return false;
                     }
-                    Namespace n = KubeResourceManager.getKubeClient()
+                    Namespace n = KubeResourceManager.get().kubeClient()
                         .getClient().namespaces().withName(namespace).get();
                     if (n != null) {
                         return n.getMetadata().getLabels().get(key) != null;

--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/PodUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/PodUtils.java
@@ -42,7 +42,7 @@ public final class PodUtils {
         Wait.until("readiness of all Pods in namespace " + namespaceName,
             TestFrameConstants.GLOBAL_POLL_INTERVAL_MEDIUM, READINESS_TIMEOUT,
             () -> {
-                List<Pod> pods = KubeResourceManager.getKubeClient().getClient()
+                List<Pod> pods = KubeResourceManager.get().kubeClient().getClient()
                     .pods().inNamespace(namespaceName).list().getItems();
                 if (pods.isEmpty()) {
                     LOGGER.debug("There are no existing Pods in Namespace {}", namespaceName);
@@ -84,7 +84,7 @@ public final class PodUtils {
         Wait.until("readiness of all Pods matching " + selector + " in Namespace " + namespaceName,
             TestFrameConstants.GLOBAL_POLL_INTERVAL_MEDIUM, READINESS_TIMEOUT,
             () -> {
-                List<Pod> pods = KubeResourceManager.getKubeClient().getClient().pods()
+                List<Pod> pods = KubeResourceManager.get().kubeClient().getClient().pods()
                     .inNamespace(namespaceName).withLabelSelector(selector).list().getItems();
                 if (pods.isEmpty() && expectPodsCount == 0) {
                     LOGGER.debug("All expected Pods {} in Namespace {} are ready", selector, namespaceName);
@@ -135,9 +135,9 @@ public final class PodUtils {
             });
         } catch (Exception ex) {
             LOGGER.warn("Pods {}/{} are not ready. Going to restart them", namespaceName, selector);
-            KubeResourceManager.getKubeClient().getClient().pods()
+            KubeResourceManager.get().kubeClient().getClient().pods()
                 .inNamespace(namespaceName).withLabelSelector(selector).list().getItems().forEach(p ->
-                    KubeResourceManager.getKubeClient().getClient().resource(p).delete());
+                    KubeResourceManager.get().kubeClient().getClient().resource(p).delete());
             waitForPodsReady(namespaceName, selector, expectedPodsCount, containersReady, () -> {
             });
         }
@@ -152,7 +152,7 @@ public final class PodUtils {
      * @return key value map podName -> uid
      */
     public static Map<String, String> podSnapshot(String namespaceName, LabelSelector selector) {
-        List<Pod> pods = KubeResourceManager.getKubeClient().getClient().pods()
+        List<Pod> pods = KubeResourceManager.get().kubeClient().getClient().pods()
             .inNamespace(namespaceName).withLabelSelector(selector).list().getItems();
         return pods.stream()
             .collect(
@@ -174,7 +174,7 @@ public final class PodUtils {
                 namespaceName, selector, phase),
             TestFrameConstants.GLOBAL_POLL_INTERVAL_SHORT, TestFrameConstants.GLOBAL_TIMEOUT,
             () -> {
-                List<Pod> existingPod = KubeResourceManager.getKubeClient().getClient().pods()
+                List<Pod> existingPod = KubeResourceManager.get().kubeClient().getClient().pods()
                     .inNamespace(namespaceName).withLabelSelector(selector).list().getItems();
                 LOGGER.debug("Considering the following Pods {}", existingPod.stream()
                     .map(p -> p.getMetadata().getName()).toList());

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
@@ -41,34 +41,34 @@ public class KubeResourceManagerTest {
 
     @BeforeEach
     void setupClient() {
-        KubeResourceManager.getKubeClient().testReconnect(kubernetesClient.getConfiguration());
+        KubeResourceManager.get().kubeClient().testReconnect(kubernetesClient.getConfiguration());
     }
 
     @Test
     void testCreateDeleteNamespace() {
         KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName("test").endMetadata().build());
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test").get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test").get());
     }
 
     @Test
     void testDeleteAllResources() {
         KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName("test2").endMetadata().build());
-        assertNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test").get());
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
+        assertNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test").get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test2").get());
         KubeResourceManager.get().deleteResources();
-        assertNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test2").get());
+        assertNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test2").get());
     }
 
     @Test
     void testUpdateResource() {
         Namespace ns = new NamespaceBuilder().withNewMetadata().withName("test3").endMetadata().build();
         KubeResourceManager.get().createResourceWithWait(ns);
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test3").get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test3").get());
         KubeResourceManager.get().updateResource(ns.edit()
             .editMetadata().addToLabels(Collections.singletonMap("test-label", "true")).endMetadata().build());
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test3").get()
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test3").get()
             .getMetadata().getLabels().get("test-label"));
     }
 
@@ -76,11 +76,11 @@ public class KubeResourceManagerTest {
     void testCreateOrUpdateResource() {
         Namespace ns = new NamespaceBuilder().withNewMetadata().withName("test4").endMetadata().build();
         KubeResourceManager.get().createResourceWithWait(ns);
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test4").get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test4").get());
         KubeResourceManager.get().createOrUpdateResourceWithWait(ns);
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test4").get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test4").get());
         KubeResourceManager.get().createOrUpdateResourceWithoutWait(ns);
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test4").get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test4").get());
     }
 
     @Test

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/UtilsTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/UtilsTest.java
@@ -34,7 +34,7 @@ public class UtilsTest {
 
     @BeforeEach
     void setupClient() {
-        KubeResourceManager.getKubeClient().testReconnect(kubernetesClient.getConfiguration());
+        KubeResourceManager.get().kubeClient().testReconnect(kubernetesClient.getConfiguration());
     }
 
     @Test
@@ -61,7 +61,7 @@ public class UtilsTest {
         LabelSelector lb = new LabelSelectorBuilder()
             .withMatchLabels(Collections.singletonMap("test-label", "true")).build();
 
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("test").get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test").get());
 
         PodUtils.waitForPodsReady("test", false, () -> {
         });
@@ -75,7 +75,7 @@ public class UtilsTest {
             new NamespaceBuilder().withNewMetadata().withName("test").endMetadata().build());
 
         KubeUtils.labelNamespace("test", "test-label", "true");
-        assertEquals("true", KubeResourceManager.getKubeClient().getClient()
+        assertEquals("true", KubeResourceManager.get().kubeClient().getClient()
             .namespaces().withName("test").get().getMetadata().getLabels().get("test-label"));
     }
 }

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleBindingType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleBindingType.java
@@ -24,7 +24,7 @@ public class ClusterRoleBindingType implements ResourceType<ClusterRoleBinding> 
      * Constructor
      */
     public ClusterRoleBindingType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().rbac().clusterRoleBindings();
+        this.client = KubeResourceManager.get().kubeClient().getClient().rbac().clusterRoleBindings();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleType.java
@@ -23,7 +23,7 @@ public class ClusterRoleType implements ResourceType<ClusterRole> {
      * Constructor
      */
     public ClusterRoleType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().rbac().clusterRoles();
+        this.client = KubeResourceManager.get().kubeClient().getClient().rbac().clusterRoles();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ConfigMapType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ConfigMapType.java
@@ -22,7 +22,7 @@ public class ConfigMapType implements ResourceType<ConfigMap> {
      * Constructor
      */
     public ConfigMapType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().configMaps();
+        this.client = KubeResourceManager.get().kubeClient().getClient().configMaps();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/CustomResourceDefinitionType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/CustomResourceDefinitionType.java
@@ -24,7 +24,8 @@ public class CustomResourceDefinitionType implements ResourceType<CustomResource
      * Constructor
      */
     public CustomResourceDefinitionType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().apiextensions().v1().customResourceDefinitions();
+        this.client = KubeResourceManager.get().kubeClient()
+            .getClient().apiextensions().v1().customResourceDefinitions();
     }
 
     /**
@@ -82,7 +83,7 @@ public class CustomResourceDefinitionType implements ResourceType<CustomResource
      * from which is the current {@link CustomResourceDefinition} resource updated
      *
      * @param resource {@link CustomResourceDefinition} resource that will be replaced
-     * @param editor       {@link Consumer} containing updates to the resource
+     * @param editor   {@link Consumer} containing updates to the resource
      */
     @Override
     public void replace(CustomResourceDefinition resource, Consumer<CustomResourceDefinition> editor) {

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/DeploymentType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/DeploymentType.java
@@ -23,7 +23,7 @@ public class DeploymentType implements ResourceType<Deployment> {
      * Constructor
      */
     public DeploymentType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().apps().deployments();
+        this.client = KubeResourceManager.get().kubeClient().getClient().apps().deployments();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/JobType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/JobType.java
@@ -23,7 +23,7 @@ public class JobType implements ResourceType<Job> {
      * Constructor
      */
     public JobType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().batch().v1().jobs();
+        this.client = KubeResourceManager.get().kubeClient().getClient().batch().v1().jobs();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/LeaseType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/LeaseType.java
@@ -23,7 +23,7 @@ public class LeaseType implements ResourceType<Lease> {
      * Constructor
      */
     public LeaseType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().leases();
+        this.client = KubeResourceManager.get().kubeClient().getClient().leases();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NamespaceType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NamespaceType.java
@@ -24,7 +24,7 @@ public class NamespaceType implements ResourceType<Namespace> {
      * Constructor
      */
     public NamespaceType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().namespaces();
+        this.client = KubeResourceManager.get().kubeClient().getClient().namespaces();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NetworkPolicyType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NetworkPolicyType.java
@@ -23,7 +23,7 @@ public class NetworkPolicyType implements ResourceType<NetworkPolicy> {
      * Constructor
      */
     public NetworkPolicyType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().network().networkPolicies();
+        this.client = KubeResourceManager.get().kubeClient().getClient().network().networkPolicies();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleBindingType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleBindingType.java
@@ -23,7 +23,7 @@ public class RoleBindingType implements ResourceType<RoleBinding> {
      * Constructor
      */
     public RoleBindingType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().rbac().roleBindings();
+        this.client = KubeResourceManager.get().kubeClient().getClient().rbac().roleBindings();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleType.java
@@ -23,7 +23,7 @@ public class RoleType implements ResourceType<Role> {
      * Constructor
      */
     public RoleType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().rbac().roles();
+        this.client = KubeResourceManager.get().kubeClient().getClient().rbac().roles();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/SecretType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/SecretType.java
@@ -23,7 +23,7 @@ public class SecretType implements ResourceType<Secret> {
      * Constructor
      */
     public SecretType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().secrets();
+        this.client = KubeResourceManager.get().kubeClient().getClient().secrets();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceAccountType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceAccountType.java
@@ -23,7 +23,7 @@ public class ServiceAccountType implements ResourceType<ServiceAccount> {
      * Constructor
      */
     public ServiceAccountType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().serviceAccounts();
+        this.client = KubeResourceManager.get().kubeClient().getClient().serviceAccounts();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceType.java
@@ -23,7 +23,7 @@ public class ServiceType implements ResourceType<Service> {
      * Constructor
      */
     public ServiceType() {
-        this.client = KubeResourceManager.getKubeClient().getClient().services();
+        this.client = KubeResourceManager.get().kubeClient().getClient().services();
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ValidatingWebhookConfigurationType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ValidatingWebhookConfigurationType.java
@@ -25,7 +25,7 @@ public class ValidatingWebhookConfigurationType implements ResourceType<Validati
      * Constructor
      */
     public ValidatingWebhookConfigurationType() {
-        this.client = KubeResourceManager.getKubeClient().getClient()
+        this.client = KubeResourceManager.get().kubeClient().getClient()
             .admissionRegistration()
             .v1()
             .validatingWebhookConfigurations();

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -208,11 +208,11 @@ public class MetricsCollector {
     private synchronized KubernetesClient getKubeClient() {
         if (kubeClient == null) {
             KubeResourceManager resourceManager = KubeResourceManager.get();
-            kubeClient = KubeResourceManager.getKubeClient().getClient();
+            kubeClient = KubeResourceManager.get().kubeClient().getClient();
             if (kubeClient == null) {
                 throw new IllegalStateException("KubeClient is not available");
             }
-            kubeClient = KubeResourceManager.getKubeClient().getClient();
+            kubeClient = KubeResourceManager.get().kubeClient().getClient();
         }
         return kubeClient;
     }
@@ -220,7 +220,7 @@ public class MetricsCollector {
     private synchronized KubeCmdClient<?> getKubeCmdClient() {
         if (kubeCmdClient == null) {
             final KubeResourceManager resourceManager = KubeResourceManager.get();
-            kubeCmdClient = KubeResourceManager.getKubeCmdClient();
+            kubeCmdClient = KubeResourceManager.get().kubeCmdClient();
             if (kubeCmdClient == null) {
                 throw new IllegalStateException("KubeCmdClient is not available");
             }

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/InstallPlanType.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/InstallPlanType.java
@@ -23,7 +23,7 @@ public class InstallPlanType implements ResourceType<InstallPlan> {
      * Constructor
      */
     public InstallPlanType() {
-        this.client = KubeResourceManager.getKubeClient().getOpenShiftClient().operatorHub().installPlans();
+        this.client = KubeResourceManager.get().kubeClient().getOpenShiftClient().operatorHub().installPlans();
     }
 
     /**

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/OperatorGroupType.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/OperatorGroupType.java
@@ -23,7 +23,7 @@ public class OperatorGroupType implements ResourceType<OperatorGroup> {
      * Constructor
      */
     public OperatorGroupType() {
-        this.client = KubeResourceManager.getKubeClient().getOpenShiftClient().operatorHub().operatorGroups();
+        this.client = KubeResourceManager.get().kubeClient().getOpenShiftClient().operatorHub().operatorGroups();
     }
 
     /**

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/SubscriptionType.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/SubscriptionType.java
@@ -23,7 +23,7 @@ public class SubscriptionType implements ResourceType<Subscription> {
      * Constructor
      */
     public SubscriptionType() {
-        this.client = KubeResourceManager.getKubeClient().getOpenShiftClient().operatorHub().subscriptions();
+        this.client = KubeResourceManager.get().kubeClient().getOpenShiftClient().operatorHub().subscriptions();
     }
 
     /**

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeClientIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeClientIT.java
@@ -19,13 +19,13 @@ public final class KubeClientIT extends AbstractIT {
 
     @Test
     void testCreateResourcesFromYaml() throws IOException {
-        List<HasMetadata> resources = KubeResourceManager.getKubeClient()
+        List<HasMetadata> resources = KubeResourceManager.get().kubeClient()
             .readResourcesFromFile(getClass().getClassLoader().getResourceAsStream("resources.yaml"));
 
         KubeResourceManager.get().createResourceWithWait(resources.toArray(new HasMetadata[0]));
 
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName4).get());
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().serviceAccounts()
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName4).get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().serviceAccounts()
             .inNamespace(nsName4).withName("skodjob-test-user").get());
     }
 }

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
@@ -43,8 +43,8 @@ public final class KubeResourceManagerCleanerIT extends AbstractIT {
 
     @AfterAll
     void afterAll() {
-        assertNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName2).get());
-        assertNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName3).get());
+        assertNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
+        assertNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName3).get());
         assertTrue(isDeleteHandlerCalled.get());
     }
 
@@ -54,29 +54,29 @@ public final class KubeResourceManagerCleanerIT extends AbstractIT {
         KubeResourceManager.get().createResourceWithWait(ns);
         assertTrue(isCreateHandlerCalled.get());
         KubeResourceManager.get().createOrUpdateResourceWithWait(ns);
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName3).get()
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName3).get()
             .getMetadata().getLabels().get("test-label"));
         KubeResourceManager.get().printAllResources(Level.INFO);
     }
 
     @Test
     void testKubeClientNamespacesExists() {
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName1).get());
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName2).get());
-        assertNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName3).get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName1).get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
+        assertNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName3).get());
     }
 
     @Test
     void testKubeCmdClientNamespacesExists() {
-        assertNotNull(KubeResourceManager.getKubeCmdClient().get("namespace", nsName1));
-        assertNotNull(KubeResourceManager.getKubeCmdClient().get("namespace", nsName2));
+        assertNotNull(KubeResourceManager.get().kubeCmdClient().get("namespace", nsName1));
+        assertNotNull(KubeResourceManager.get().kubeCmdClient().get("namespace", nsName2));
         assertThrows(KubeClusterException.class, () ->
-            KubeResourceManager.getKubeCmdClient().get("namespace", nsName3));
+            KubeResourceManager.get().kubeCmdClient().get("namespace", nsName3));
     }
 
     @Test
     void testCreateMultipleResourcesAsync() throws IOException {
-        List<HasMetadata> resources = KubeResourceManager.getKubeClient()
+        List<HasMetadata> resources = KubeResourceManager.get().kubeClient()
             .readResourcesFromFile(getClass().getClassLoader().getResourceAsStream("metrics-example.yaml"));
         KubeResourceManager.get().createOrUpdateResourceAsyncWait(resources.toArray(new HasMetadata[0]));
     }

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
@@ -28,7 +28,7 @@ public final class KubeResourceManagerIT extends AbstractIT {
 
     @AfterEach
     void afterEach() {
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName2).get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
         KubeResourceManager.get().deleteResources();
     }
 
@@ -36,8 +36,8 @@ public final class KubeResourceManagerIT extends AbstractIT {
     void createResource() {
         KubeResourceManager.get().createResourceWithWait(
             new NamespaceBuilder().withNewMetadata().withName("test2").endMetadata().build());
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName1).get());
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName(nsName2).get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName1).get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
         KubeResourceManager.get().deleteResource(false, ns1);
         assertTrue(isDeleteHandlerCalled.get());
     }

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
@@ -157,10 +157,11 @@ public class LogCollectorIT extends AbstractIT {
         logCollector.collectClusterWideResourcesToFolder(folderPath);
         logCollector.collectClusterWideResourcesToFolder(false, folderPath);
 
-        List<String> podNames = KubeResourceManager.getKubeClient()
+        List<String> podNames = KubeResourceManager.get().kubeClient()
             .listPods(namespaceName1).stream().map(pod -> pod.getMetadata().getName()).toList();
-        List<String> secretNames = KubeResourceManager.getKubeClient().getClient().secrets().inNamespace(namespaceName1)
-            .list().getItems().stream().map(secret -> secret.getMetadata().getName()).toList();
+        List<String> secretNames = KubeResourceManager.get().kubeClient()
+            .getClient().secrets().inNamespace(namespaceName1).list().getItems().stream()
+            .map(secret -> secret.getMetadata().getName()).toList();
 
         File rootFolder = Paths.get(fullFolderPath).toFile();
 
@@ -229,7 +230,7 @@ public class LogCollectorIT extends AbstractIT {
                 assertTrue(configMapFolderFileNames
                         .contains(LogCollectorUtils.getYamlFileNameForResource(configMapName)));
             } else if (namespaceFolder.getName().equals(CollectorConstants.CLUSTER_WIDE_FOLDER)) {
-                int countOfNodes = KubeResourceManager.getKubeClient().getClient().nodes().list().getItems().size();
+                int countOfNodes = KubeResourceManager.get().kubeClient().getClient().nodes().list().getItems().size();
                 int countOfFiles = Objects.requireNonNull(
                     Arrays.stream(Objects.requireNonNull(namespaceFolder.listFiles()))
                         .filter(file -> file.getName().equals("nodes")).toList()

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
@@ -28,22 +28,22 @@ public final class MetricsCollectorIT extends AbstractIT {
     @Test
     void testCollectMetrics() throws IOException {
         //Create deployment
-        List<HasMetadata> resources = KubeResourceManager.getKubeClient()
+        List<HasMetadata> resources = KubeResourceManager.get().kubeClient()
             .readResourcesFromFile(getClass().getClassLoader().getResourceAsStream("metrics-example.yaml"));
 
         KubeResourceManager.get().createResourceAsyncWait(resources.toArray(new HasMetadata[0]));
 
         // Check deployment is not null
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("metrics-test").get());
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().apps().deployments()
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("metrics-test").get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().apps().deployments()
             .inNamespace("metrics-test").withName("prometheus-example").get());
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().apps().deployments()
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().apps().deployments()
             .inNamespace("metrics-test").withName("scraper-pod").get());
 
         // Create metrics collector
         MetricsCollector collector = new MetricsCollector.Builder()
             .withNamespaceName("metrics-test")
-            .withScraperPodName(KubeResourceManager.getKubeClient()
+            .withScraperPodName(KubeResourceManager.get().kubeClient()
                 .listPodsByPrefixInName("metrics-test", "scraper-pod").get(0)
                 .getMetadata().getName())
             .withComponent(new MetricsComponent() {
@@ -65,7 +65,7 @@ public final class MetricsCollectorIT extends AbstractIT {
 
         assertDoesNotThrow(() -> collector.collectMetricsFromPods(30000)); // timeout in milliseconds
         Map<String, List<Metric>> metrics = collector.getCollectedData();
-        assertTrue(metrics.containsKey(KubeResourceManager.getKubeClient()
+        assertTrue(metrics.containsKey(KubeResourceManager.get().kubeClient()
             .listPodsByPrefixInName("metrics-test", "prometheus-example").get(0)
             .getMetadata().getName()));
     }
@@ -73,15 +73,15 @@ public final class MetricsCollectorIT extends AbstractIT {
     @Test
     void testCollectMetricsWithAutoDeployedPod() throws IOException {
         //Create deployment
-        List<HasMetadata> resources = KubeResourceManager.getKubeClient()
+        List<HasMetadata> resources = KubeResourceManager.get().kubeClient()
             .readResourcesFromFile(getClass().getClassLoader().getResourceAsStream("metrics-example.yaml"))
             .stream().filter(resource -> !resource.getMetadata().getName().equals("scraper-pod")).toList();
 
         KubeResourceManager.get().createResourceWithWait(resources.toArray(new HasMetadata[0]));
 
         // Check deployment is not null
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().namespaces().withName("metrics-test").get());
-        assertNotNull(KubeResourceManager.getKubeClient().getClient().apps().deployments()
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("metrics-test").get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().apps().deployments()
             .inNamespace("metrics-test").withName("prometheus-example").get());
 
         // Create metrics collector
@@ -110,7 +110,7 @@ public final class MetricsCollectorIT extends AbstractIT {
         // Collect metrics
         assertDoesNotThrow(() -> collector.collectMetricsFromPods(30000)); // timeout in milliseconds
         Map<String, List<Metric>> metrics = collector.getCollectedData();
-        assertTrue(metrics.containsKey(KubeResourceManager.getKubeClient()
+        assertTrue(metrics.containsKey(KubeResourceManager.get().kubeClient()
             .listPodsByPrefixInName("metrics-test", "prometheus-example").get(0)
             .getMetadata().getName()));
 
@@ -120,7 +120,7 @@ public final class MetricsCollectorIT extends AbstractIT {
         // Collect metrics
         assertDoesNotThrow(() -> collector2.collectMetricsFromPods(30000)); // timeout in milliseconds
         Map<String, List<Metric>> metrics2 = collector.getCollectedData();
-        assertTrue(metrics2.containsKey(KubeResourceManager.getKubeClient()
+        assertTrue(metrics2.containsKey(KubeResourceManager.get().kubeClient()
             .listPodsByPrefixInName("metrics-test", "prometheus-example").get(0)
             .getMetadata().getName()));
     }


### PR DESCRIPTION
## Description

1. Remove static ability to get clients because clients are not initialized without singleton is initialized first so it is save to get it from instance.
2. remove the get.. prefix from kubeClient() and kubeCmdClient()


## Type of Change

Please delete options that are not relevant.

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
