### PR TITLE
Remove all github distManagement configuration for snapshots

### DIFF
--- a/test-frame-common/pom.xml
+++ b/test-frame-common/pom.xml
@@ -34,14 +34,6 @@
         <url>https://github.com/skodjob/test-frame/issues</url>
     </issueManagement>
 
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/skodjob/test-frame</url>
-        </repository>
-    </distributionManagement>
-
     <developers>
         <developer>
             <id>im-konge</id>

--- a/test-frame-kubernetes/pom.xml
+++ b/test-frame-kubernetes/pom.xml
@@ -33,14 +33,6 @@
         <url>https://github.com/skodjob/test-frame/issues</url>
     </issueManagement>
 
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/skodjob/test-frame</url>
-        </repository>
-    </distributionManagement>
-
     <developers>
         <developer>
             <id>im-konge</id>

--- a/test-frame-log-collector/pom.xml
+++ b/test-frame-log-collector/pom.xml
@@ -33,14 +33,6 @@
         <url>https://github.com/skodjob/test-frame/issues</url>
     </issueManagement>
 
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/skodjob/test-frame</url>
-        </repository>
-    </distributionManagement>
-
     <developers>
         <developer>
             <id>im-konge</id>

--- a/test-frame-metrics-collector/pom.xml
+++ b/test-frame-metrics-collector/pom.xml
@@ -34,14 +34,6 @@
         <url>https://github.com/skodjob/test-frame/issues</url>
     </issueManagement>
 
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/skodjob/test-frame</url>
-        </repository>
-    </distributionManagement>
-
     <developers>
         <developer>
             <id>im-konge</id>

--- a/test-frame-openshift/pom.xml
+++ b/test-frame-openshift/pom.xml
@@ -33,14 +33,6 @@
         <url>https://github.com/skodjob/test-frame/issues</url>
     </issueManagement>
 
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/skodjob/test-frame</url>
-        </repository>
-    </distributionManagement>
-
     <developers>
         <developer>
             <id>im-konge</id>


### PR DESCRIPTION
## Description

Fix for snapshot dist management


## Type of Change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
