### PR TITLE
Disable generating pom backups when release tag version is set

### DIFF
--- a/.github/scripts/prepare-tag-release.sh
+++ b/.github/scripts/prepare-tag-release.sh
@@ -8,7 +8,7 @@
 TAG=$1
 echo "Tagging version to ${TAG}"
 
-./mvnw versions:set -DnewVersion=${TAG}
+./mvnw versions:set -DnewVersion=${TAG} -DgenerateBackupPoms=false
 ./mvnw clean install
 git add "."
 git diff --staged --quiet || git commit -m "Release ${TAG}"


### PR DESCRIPTION
## Description

Disable generating pom backups when release tag version is set


## Type of Change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
