### PR TITLE
Add possibility to specify resource readiness timeout

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/TestFrameConstants.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/TestFrameConstants.java
@@ -43,6 +43,11 @@ public interface TestFrameConstants {
     long GLOBAL_TIMEOUT = Duration.ofMinutes(10).toMillis();
 
     /**
+     * Global timeout in milliseconds.
+     */
+    long GLOBAL_TIMEOUT_SHORT = Duration.ofMinutes(5).toMillis();
+
+    /**
      * Stability timeout in milliseconds
      */
     long GLOBAL_STABILITY_TIME = Duration.ofMinutes(1).toMillis();

--- a/test-frame-common/src/main/java/io/skodjob/testframe/interfaces/ResourceType.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/interfaces/ResourceType.java
@@ -31,6 +31,13 @@ public interface ResourceType<T extends HasMetadata> {
     String getKind();
 
     /**
+     * Timeout for resource readiness
+     *
+     * @return  timeout for resource readiness
+     */
+    Long getTimeoutForResourceReadiness();
+
+    /**
      * Creates specific {@link T} resource
      *
      * @param resource {@link T} resource

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleBindingType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleBindingType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingList;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -45,6 +46,16 @@ public class ClusterRoleBindingType implements ResourceType<ClusterRoleBinding> 
     @Override
     public String getKind() {
         return "ClusterRoleBinding";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ClusterRoleType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleList;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -34,6 +35,16 @@ public class ClusterRoleType implements ResourceType<ClusterRole> {
     @Override
     public String getKind() {
         return "ClusterRole";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ConfigMapType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ConfigMapType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -33,6 +34,16 @@ public class ConfigMapType implements ResourceType<ConfigMap> {
     @Override
     public String getKind() {
         return "ConfigMap";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/CustomResourceDefinitionType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/CustomResourceDefinitionType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -36,6 +37,16 @@ public class CustomResourceDefinitionType implements ResourceType<CustomResource
     @Override
     public String getKind() {
         return "CustomResourceDefinition";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/DeploymentType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/DeploymentType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -34,6 +35,16 @@ public class DeploymentType implements ResourceType<Deployment> {
     @Override
     public String getKind() {
         return "Deployment";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/JobType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/JobType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -34,6 +35,16 @@ public class JobType implements ResourceType<Job> {
     @Override
     public String getKind() {
         return "Job";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/LeaseType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/LeaseType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.coordination.v1.Lease;
 import io.fabric8.kubernetes.api.model.coordination.v1.LeaseList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -34,6 +35,16 @@ public class LeaseType implements ResourceType<Lease> {
     @Override
     public String getKind() {
         return "Lease";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NamespaceType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NamespaceType.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.NamespaceList;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -35,6 +36,16 @@ public class NamespaceType implements ResourceType<Namespace> {
     @Override
     public String getKind() {
         return "Namespace";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NetworkPolicyType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/NetworkPolicyType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -34,6 +35,16 @@ public class NetworkPolicyType implements ResourceType<NetworkPolicy> {
     @Override
     public String getKind() {
         return "NetworkPolicy";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleBindingType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleBindingType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -34,6 +35,16 @@ public class RoleBindingType implements ResourceType<RoleBinding> {
     @Override
     public String getKind() {
         return "RoleBinding";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/RoleType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -34,6 +35,16 @@ public class RoleType implements ResourceType<Role> {
     @Override
     public String getKind() {
         return "Role";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/SecretType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/SecretType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -34,6 +35,16 @@ public class SecretType implements ResourceType<Secret> {
     @Override
     public String getKind() {
         return "Secret";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceAccountType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceAccountType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -34,6 +35,16 @@ public class ServiceAccountType implements ResourceType<ServiceAccount> {
     @Override
     public String getKind() {
         return "ServiceAccount";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ServiceType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.ServiceResource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -34,6 +35,16 @@ public class ServiceType implements ResourceType<Service> {
     @Override
     public String getKind() {
         return "Service";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ValidatingWebhookConfigurationType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/ValidatingWebhookConfigurationType.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhoo
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfigurationList;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 /**
@@ -39,6 +40,16 @@ public class ValidatingWebhookConfigurationType implements ResourceType<Validati
     @Override
     public String getKind() {
         return "ValidatingWebhookConfiguration";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/BuildConfigType.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/BuildConfigType.java
@@ -10,6 +10,7 @@ import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigList;
 import io.fabric8.openshift.client.dsl.BuildConfigResource;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 import java.util.function.Consumer;
@@ -46,6 +47,16 @@ public class BuildConfigType implements ResourceType<BuildConfig> {
     @Override
     public String getKind() {
         return "BuildConfig";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/ImageStreamType.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/ImageStreamType.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.api.model.ImageStreamList;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 import java.util.function.Consumer;
@@ -45,6 +46,16 @@ public class ImageStreamType implements ResourceType<ImageStream> {
     @Override
     public String getKind() {
         return "ImageStream";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/InstallPlanType.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/InstallPlanType.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.InstallPlan;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.InstallPlanList;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 import java.util.function.Consumer;
@@ -34,6 +35,16 @@ public class InstallPlanType implements ResourceType<InstallPlan> {
     @Override
     public String getKind() {
         return "OperatorGroup";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/OperatorGroupType.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/OperatorGroupType.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorGroup;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorGroupList;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 import java.util.function.Consumer;
@@ -34,6 +35,16 @@ public class OperatorGroupType implements ResourceType<OperatorGroup> {
     @Override
     public String getKind() {
         return "OperatorGroup";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/SubscriptionType.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/resources/SubscriptionType.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.Subscription;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.SubscriptionList;
+import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.interfaces.ResourceType;
 
 import java.util.function.Consumer;
@@ -34,6 +35,16 @@ public class SubscriptionType implements ResourceType<Subscription> {
     @Override
     public String getKind() {
         return "Subscription";
+    }
+
+    /**
+     * Timeout for resource readiness
+     *
+     * @return timeout for resource readiness
+     */
+    @Override
+    public Long getTimeoutForResourceReadiness() {
+        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
     }
 
     /**


### PR DESCRIPTION
## Description

This PR adds possibility to specify the readiness timeout for resources. The default (10 minutes) is still considered as default. In case that we want smaller (or bigger) timeout, we can simply configure it in resource's type class.

## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit/integration tests pass locally with my changes
