### PR TITLE
[Fix] Time constant

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/TestFrameConstants.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/TestFrameConstants.java
@@ -45,7 +45,7 @@ public interface TestFrameConstants {
     /**
      * Global timeout in milliseconds.
      */
-    long GLOBAL_TIMEOUT_SHORT = Duration.ofMinutes(5).toMillis();
+    long GLOBAL_TIMEOUT_SHORT = Duration.ofMinutes(3).toMillis();
 
     /**
      * Stability timeout in milliseconds

--- a/test-frame-common/src/main/java/io/skodjob/testframe/interfaces/ResourceType.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/interfaces/ResourceType.java
@@ -33,12 +33,12 @@ public interface ResourceType<T extends HasMetadata> {
 
     /**
      * Timeout for resource readiness.
-     * Defaults to {@link TestFrameConstants#GLOBAL_TIMEOUT_SHORT}.
+     * Defaults to {@link TestFrameConstants#GLOBAL_TIMEOUT_MEDIUM}.
      *
      * @return  timeout for resource readiness
      */
     default Long getTimeoutForResourceReadiness() {
-        return TestFrameConstants.GLOBAL_TIMEOUT_SHORT;
+        return TestFrameConstants.GLOBAL_TIMEOUT_MEDIUM;
     }
 
     /**

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -388,7 +388,7 @@ public class KubeResourceManager {
                 }
                 if (waitReady) {
                     long resourceTimeout = Objects.requireNonNullElse(type.getTimeoutForResourceReadiness(),
-                        TestFrameConstants.GLOBAL_TIMEOUT_SHORT);
+                        TestFrameConstants.GLOBAL_TIMEOUT_MEDIUM);
                     CompletableFuture<Void> c = CompletableFuture.runAsync(() ->
                         assertTrue(waitResourceCondition(resource, ResourceCondition.readiness(type), resourceTimeout),
                             String.format("Timed out waiting for %s/%s in %s to be ready", resource.getKind(),


### PR DESCRIPTION
## Description

Just a small nit i bumped into while integrating. It was a duplicate of  `long GLOBAL_TIMEOUT_MEDIUM = Duration.ofMinutes(5L).toMillis();`. So this PR sets it to lower value which seems reasonable short.

## Type of Change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit/integration tests pass locally with my changes
