### PR TITLE
Add option to skip-tls-verify for pulling bundle image in operator-sdk command

### DIFF
--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/olm/OperatorSdkRun.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/olm/OperatorSdkRun.java
@@ -26,12 +26,14 @@ public class OperatorSdkRun {
     protected String indexImage;
     protected String kubeconfig;
     protected String bundleImage;
+    protected boolean skipTlsVerify;
 
     private static final String OPTION_INDEX_IMAGE = "--index-image";
     private static final String OPTION_NAMESPACE = "--namespace";
     private static final String OPTION_KUBECONFIG = "--kubeconfig";
     private static final String OPTION_TIMEOUT = "--timeout";
     private static final String OPTION_INSTALL_MODE = "--install-mode";
+    private static final String OPTION_SKIP_TLS_VERIFY = "--skip-tls-verify";
     private static final String CMD = "operator-sdk";
     private static final String RUN = "run";
     private static final String BUNDLE = "bundle";
@@ -60,6 +62,7 @@ public class OperatorSdkRun {
         this.timeout = operatorSdkRunBuilder.getTimeout();
         this.indexImage = operatorSdkRunBuilder.getIndexImage();
         this.kubeconfig = operatorSdkRunBuilder.getKubeconfig();
+        this.skipTlsVerify = operatorSdkRunBuilder.getSkipTlsVerify();
     }
 
     /**
@@ -82,12 +85,16 @@ public class OperatorSdkRun {
 
         if (timeout != null) {
             command.add(OPTION_TIMEOUT);
-            command.add(String.valueOf(timeout));
+            command.add(timeout);
         }
 
         if (kubeconfig != null) {
             command.add(OPTION_KUBECONFIG);
             command.add(kubeconfig);
+        }
+
+        if (skipTlsVerify) {
+            command.add(OPTION_SKIP_TLS_VERIFY);
         }
 
         return Exec.exec(command);

--- a/test-frame-openshift/src/main/java/io/skodjob/testframe/olm/OperatorSdkRunBuilder.java
+++ b/test-frame-openshift/src/main/java/io/skodjob/testframe/olm/OperatorSdkRunBuilder.java
@@ -15,6 +15,7 @@ public class OperatorSdkRunBuilder {
     private String indexImage;
     private String kubeconfig;
     private String bundleImage;
+    private boolean skipTlsVerify;
 
 
     /**
@@ -30,6 +31,7 @@ public class OperatorSdkRunBuilder {
         this.indexImage = operatorSdkRun.indexImage;
         this.kubeconfig = operatorSdkRun.kubeconfig;
         this.bundleImage = operatorSdkRun.bundleImage;
+        this.skipTlsVerify = operatorSdkRun.skipTlsVerify;
     }
 
     /**
@@ -107,6 +109,17 @@ public class OperatorSdkRunBuilder {
     }
 
     /**
+     * Method for setting the skip TLS certificate verification for container image registries while pulling bundles
+     *
+     * @param skipTlsVerify set skip tls verify
+     * @return {@link OperatorSdkRunBuilder} object
+     */
+    public OperatorSdkRunBuilder withSkipTlsVerify(boolean skipTlsVerify) {
+        this.skipTlsVerify = skipTlsVerify;
+        return this;
+    }
+
+    /**
      * Get namespace
      *
      * @return namespace
@@ -158,6 +171,15 @@ public class OperatorSdkRunBuilder {
      */
     public String getBundleImage() {
         return bundleImage;
+    }
+
+    /**
+     * Get skipTlsVerify
+     *
+     * @return skipTlsVerify
+     */
+    public boolean getSkipTlsVerify() {
+        return skipTlsVerify;
     }
 
     /**

--- a/test-frame-openshift/src/test/java/io/skodjob/testframe/olm/OperatorSdkRunBuilderTest.java
+++ b/test-frame-openshift/src/test/java/io/skodjob/testframe/olm/OperatorSdkRunBuilderTest.java
@@ -11,6 +11,7 @@ import java.security.InvalidParameterException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OperatorSdkRunBuilderTest {
 
@@ -23,6 +24,7 @@ public class OperatorSdkRunBuilderTest {
             .withIndexImage("my-index-image")
             .withKubeConfig("path-to-kubeconfig")
             .withInstallMode("automatic")
+            .withSkipTlsVerify(true)
             .build();
 
         assertNotNull(operatorSdkRun);
@@ -33,6 +35,7 @@ public class OperatorSdkRunBuilderTest {
         assertEquals("namespace-1", operatorSdkRun.namespace);
         assertEquals("automatic", operatorSdkRun.installMode);
         assertEquals("path-to-kubeconfig", operatorSdkRun.kubeconfig);
+        assertTrue(operatorSdkRun.skipTlsVerify);
     }
 
     @Test


### PR DESCRIPTION
## Description

Add option to skip-tls-verify for pulling bundle image from registry without proper cert.


## Type of Change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)
