### PR TITLE
Add cluster utils methods for identify if kube is multinode or has openshift api

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/KubeUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/KubeUtils.java
@@ -99,4 +99,23 @@ public final class KubeUtils {
                 });
         }
     }
+
+    /**
+     * Is current cluster openshift
+     *
+     * @return true if cluster is openshift
+     */
+    public static boolean isOcp() {
+        return KubeResourceManager.get().kubeCmdClient()
+            .exec(false, false, "api-versions").out().contains("openshift.io");
+    }
+
+    /**
+     * Is multinode cluster
+     *
+     * @return true if cluster is multinode
+     */
+    public static boolean isMultinode() {
+        return KubeResourceManager.get().kubeClient().getClient().nodes().list().getItems().size() > 1;
+    }
 }


### PR DESCRIPTION
## Description

Added methods for identify ocp api and multinode cluster


## Type of Change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

