### PR TITLE
Fix PrometheusParser + tests

### DIFF
--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -207,7 +207,6 @@ public class MetricsCollector {
 
     private synchronized KubernetesClient getKubeClient() {
         if (kubeClient == null) {
-            KubeResourceManager resourceManager = KubeResourceManager.get();
             kubeClient = KubeResourceManager.get().kubeClient().getClient();
             if (kubeClient == null) {
                 throw new IllegalStateException("KubeClient is not available");
@@ -219,7 +218,6 @@ public class MetricsCollector {
 
     private synchronized KubeCmdClient<?> getKubeCmdClient() {
         if (kubeCmdClient == null) {
-            final KubeResourceManager resourceManager = KubeResourceManager.get();
             kubeCmdClient = KubeResourceManager.get().kubeCmdClient();
             if (kubeCmdClient == null) {
                 throw new IllegalStateException("KubeCmdClient is not available");

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -590,9 +590,12 @@ public class MetricsCollector {
 
             try {
                 final String metrics = collectMetrics(podIP, podName);
+                final List<Metric> parsedMetrics = PrometheusTextFormatParser.parse(metrics);
+
                 map.put(podName, PrometheusTextFormatParser.parse(metrics));
                 LOGGER.info("Finished metrics collection from {}", podName);
                 LOGGER.debug("Collected metrics from {}: {}", podName, metrics);
+                LOGGER.debug("Parsed metrics from {}:\n{}", podName, parsedMetrics);
             } catch (InterruptedException | ExecutionException | IOException e) {
                 LOGGER.error("Failed to collect metrics from {}: {}", podName, e.getMessage());
                 errorMap.put(podName, e.getMessage()); // Store the error message

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -592,7 +592,7 @@ public class MetricsCollector {
                 final String metrics = collectMetrics(podIP, podName);
                 final List<Metric> parsedMetrics = PrometheusTextFormatParser.parse(metrics);
 
-                map.put(podName, PrometheusTextFormatParser.parse(metrics));
+                map.put(podName, parsedMetrics);
                 LOGGER.info("Finished metrics collection from {}", podName);
                 LOGGER.debug("Collected metrics from {}: {}", podName, metrics);
                 LOGGER.debug("Parsed metrics from {}:\n{}", podName, parsedMetrics);

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/PrometheusTextFormatParser.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/PrometheusTextFormatParser.java
@@ -37,71 +37,67 @@ public class PrometheusTextFormatParser {
         Summary currentSummary = null;
 
         while ((line = reader.readLine()) != null) {
-            String[] parts = line.split(" ");
-
             if (line.startsWith("#")) {
                 if (line.contains("TYPE")) {
+                    String[] parts = line.split(" ");
                     type = parts[3];
                 }
-                continue; // Skip comments and help definition
+                continue;
             }
+            int lastSpace = line.lastIndexOf(' ');
+            if (lastSpace == -1) continue;
+            String metricNameAndLabels = line.substring(0, lastSpace);
+            String valueStr = line.substring(lastSpace + 1).trim();
+            double value = Double.parseDouble(valueStr);
 
-            if (parts.length == 2) {
-                String metricNameAndLabels = parts[0];
-                double value = Double.parseDouble(parts[1]);
+            String[] nameAndLabels = parseNameAndLabels(metricNameAndLabels);
+            String name = nameAndLabels[0];
+            Map<String, String> labels = parseLabels(nameAndLabels[1]);
+            Map<String, String> customLabels = getCustomLabels(labels);
 
-                String[] nameAndLabels = parseNameAndLabels(metricNameAndLabels);
-                String name = nameAndLabels[0];
-                Map<String, String> labels = parseLabels(nameAndLabels[1]);
-                // `customLabels` represents labels that are not part of the Prometheus metrics
-                // (like buckets or summary) - the `le` and `quantile` labels are removed,
-                // because they are parsed in a different way
-                Map<String, String> customLabels = getCustomLabels(labels);
-
-                if (name.endsWith("_total")) {
-                    metrics.add(new Counter(name, customLabels, line, value));
-                } else if (name.contains("_bucket")) {
-                    if (currentHistogram == null || !currentHistogram.name.equals(name)
-                        || !currentHistogram.labels.equals(customLabels)) {
-                        currentHistogram = new Histogram(name, customLabels, line);
-                        metrics.add(currentHistogram);
-                    }
-                    double upperBound = labels.get("le").contains("+Inf") ?
-                        Double.MAX_VALUE : Double.parseDouble(labels.get("le"));
-                    currentHistogram.addBucket(upperBound, value);
-                } else if (name.endsWith("_sum")) {
-                    if (currentHistogram != null && currentHistogram.name.equals(name.replace("_sum", "_bucket"))
-                        && currentHistogram.labels.equals(customLabels)) {
-                        currentHistogram.setSum(value);
-                    } else if (currentSummary != null && currentSummary.name.equals(name.replace("_sum", ""))
-                        && currentSummary.labels.equals(customLabels)) {
-                        currentSummary.setSum(value);
-                    }
-                } else if (name.endsWith("_count")) {
-                    if (currentHistogram != null && currentHistogram.name.equals(name.replace("_count", "_bucket"))
-                        && currentHistogram.labels.equals(customLabels)) {
-                        currentHistogram.setCount((int) value);
-                    } else if (currentSummary != null && currentSummary.name.equals(name.replace("_count", ""))
-                        && currentSummary.labels.equals(customLabels)) {
-                        currentSummary.setCount((int) value);
-                    } else if (type != null) {
-                        if (type.equals("gauge")) {
-                            metrics.add(new Gauge(name, customLabels, line, value));
-                        } else if (type.equals("counter")) {
-                            metrics.add(new Counter(name, customLabels, line, value));
-                        }
-                    }
-                } else if (name.contains("{quantile=")) {
-                    if (currentSummary == null || !currentSummary.name.equals(name)
-                        || !currentSummary.labels.equals(customLabels)) {
-                        currentSummary = new Summary(name, customLabels, line);
-                        metrics.add(currentSummary);
-                    }
-                    double quantile = Double.parseDouble(labels.get("quantile"));
-                    currentSummary.addQuantile(quantile, value);
-                } else {
-                    metrics.add(new Gauge(name, labels, line, value));
+            if (name.endsWith("_total")) {
+                metrics.add(new Counter(name, customLabels, line, value));
+            } else if (name.contains("_bucket")) {
+                if (currentHistogram == null || !currentHistogram.name.equals(name) || !currentHistogram.labels.equals(customLabels)) {
+                    currentHistogram = new Histogram(name, customLabels, line);
+                    metrics.add(currentHistogram);
                 }
+                double upperBound = labels.get("le").contains("+Inf") ?
+                    Double.MAX_VALUE : Double.parseDouble(labels.get("le"));
+                currentHistogram.addBucket(upperBound, value);
+            } else if (name.endsWith("_sum")) {
+                String baseName = name.substring(0, name.length() - 4);
+                if (currentHistogram != null && currentHistogram.name.equals(baseName + "_bucket")
+                    && currentHistogram.labels.equals(customLabels)) {
+                    currentHistogram.setSum(value);
+                } else if (currentSummary != null && currentSummary.name.equals(baseName)
+                    && currentSummary.labels.equals(customLabels)) {
+                    currentSummary.setSum(value);
+                }
+            } else if (name.endsWith("_count")) {
+                String baseName = name.substring(0, name.length() - 6);
+                if (currentHistogram != null && currentHistogram.name.equals(baseName + "_bucket")
+                    && currentHistogram.labels.equals(customLabels)) {
+                    currentHistogram.setCount((int) value);
+                } else if (currentSummary != null && currentSummary.name.equals(baseName)
+                    && currentSummary.labels.equals(customLabels)) {
+                    currentSummary.setCount((int) value);
+                } else if (type != null) {
+                    if (type.equals("gauge")) {
+                        metrics.add(new Gauge(name, customLabels, line, value));
+                    } else if (type.equals("counter")) {
+                        metrics.add(new Counter(name, customLabels, line, value));
+                    }
+                }
+            } else if (labels.containsKey("quantile")) {
+                if (currentSummary == null || !currentSummary.name.equals(name) || !currentSummary.labels.equals(customLabels)) {
+                    currentSummary = new Summary(name, customLabels, line);
+                    metrics.add(currentSummary);
+                }
+                double quantile = Double.parseDouble(labels.get("quantile"));
+                currentSummary.addQuantile(quantile, value);
+            } else {
+                metrics.add(new Gauge(name, labels, line, value));
             }
         }
         return metrics;
@@ -116,12 +112,11 @@ public class PrometheusTextFormatParser {
      */
     private static Map<String, String> getCustomLabels(Map<String, String> labels) {
         Map<String, String> customLabels = new HashMap<>(labels);
-
         customLabels.remove("le");
         customLabels.remove("quantile");
-
         return customLabels;
     }
+
 
     private static String[] parseNameAndLabels(String metricNameAndLabels) {
         int labelStartIndex = metricNameAndLabels.indexOf('{');
@@ -135,15 +130,13 @@ public class PrometheusTextFormatParser {
 
     private static Map<String, String> parseLabels(String labelString) {
         Map<String, String> labels = new HashMap<>();
-        if (labelString.isEmpty()) {
-            return labels;
-        }
+        if (labelString.isEmpty()) return labels;
         labelString = labelString.substring(1, labelString.length() - 1); // Remove curly braces
         String[] labelPairs = labelString.split(",");
         for (String labelPair : labelPairs) {
             String[] keyValue = labelPair.split("=");
             String key = keyValue[0];
-            String value = keyValue[1].replaceAll("^\"|\"$", ""); // Remove quotes
+            String value = keyValue[1].replaceAll("^\"|\"$", "");
             labels.put(key, value);
         }
         return labels;

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/PrometheusTextFormatParser.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/PrometheusTextFormatParser.java
@@ -58,7 +58,9 @@ public class PrometheusTextFormatParser {
             if (name.endsWith("_total")) {
                 metrics.add(new Counter(name, customLabels, line, value));
             } else if (name.contains("_bucket")) {
-                if (currentHistogram == null || !currentHistogram.name.equals(name) || !currentHistogram.labels.equals(customLabels)) {
+                if (currentHistogram == null
+                    || !currentHistogram.name.equals(name)
+                    || !currentHistogram.labels.equals(customLabels)) {
                     currentHistogram = new Histogram(name, customLabels, line);
                     metrics.add(currentHistogram);
                 }
@@ -90,7 +92,9 @@ public class PrometheusTextFormatParser {
                     }
                 }
             } else if (labels.containsKey("quantile")) {
-                if (currentSummary == null || !currentSummary.name.equals(name) || !currentSummary.labels.equals(customLabels)) {
+                if (currentSummary == null
+                    || !currentSummary.name.equals(name)
+                    || !currentSummary.labels.equals(customLabels)) {
                     currentSummary = new Summary(name, customLabels, line);
                     metrics.add(currentSummary);
                 }

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/PrometheusTextFormatParser.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/metrics/PrometheusTextFormatParser.java
@@ -40,12 +40,17 @@ public class PrometheusTextFormatParser {
             if (line.startsWith("#")) {
                 if (line.contains("TYPE")) {
                     String[] parts = line.split(" ");
+                    // e.g. # TYPE metric_name histogram => "histogram" is at parts[3]
                     type = parts[3];
                 }
                 continue;
             }
             int lastSpace = line.lastIndexOf(' ');
-            if (lastSpace == -1) continue;
+            if (lastSpace == -1) {
+                // Invalid line, skip
+                continue;
+            }
+
             String metricNameAndLabels = line.substring(0, lastSpace);
             String valueStr = line.substring(lastSpace + 1).trim();
             double value = Double.parseDouble(valueStr);
@@ -56,45 +61,66 @@ public class PrometheusTextFormatParser {
             Map<String, String> customLabels = getCustomLabels(labels);
 
             if (name.endsWith("_total")) {
+                // Standard Prometheus pattern for counters
                 metrics.add(new Counter(name, customLabels, line, value));
+
             } else if (name.contains("_bucket")) {
+                // It's a bucket line (histogram)
                 if (currentHistogram == null
                     || !currentHistogram.name.equals(name)
                     || !currentHistogram.labels.equals(customLabels)) {
                     currentHistogram = new Histogram(name, customLabels, line);
                     metrics.add(currentHistogram);
                 }
-                double upperBound = labels.get("le").contains("+Inf") ?
-                    Double.MAX_VALUE : Double.parseDouble(labels.get("le"));
+                double upperBound = labels.get("le").contains("+Inf")
+                    ? Double.MAX_VALUE
+                    : Double.parseDouble(labels.get("le"));
                 currentHistogram.addBucket(upperBound, value);
+
             } else if (name.endsWith("_sum")) {
+                // Possibly part of a histogram or summary
                 String baseName = name.substring(0, name.length() - 4);
-                if (currentHistogram != null && currentHistogram.name.equals(baseName + "_bucket")
+
+                // If it matches the ongoing histogram
+                if (currentHistogram != null
+                    && currentHistogram.name.equals(baseName + "_bucket")
                     && currentHistogram.labels.equals(customLabels)) {
                     currentHistogram.setSum(value);
-                } else if (currentSummary != null && currentSummary.name.equals(baseName)
+                // If it matches the ongoing summary
+                } else if (currentSummary != null
+                    && currentSummary.name.equals(baseName)
                     && currentSummary.labels.equals(customLabels)) {
                     currentSummary.setSum(value);
-                } else {
-                    // Fallback: treat orphaned _sum as a Gauge.
-                    metrics.add(new Gauge(name, customLabels, line, value));
                 }
+
+                // Regardless of histogram/summary match, also treat it as a Gauge for easy collection
+                metrics.add(new Gauge(name, customLabels, line, value));
+
             } else if (name.endsWith("_count")) {
+                // Possibly part of a histogram or summary
                 String baseName = name.substring(0, name.length() - 6);
-                if (currentHistogram != null && currentHistogram.name.equals(baseName + "_bucket")
+
+                if (currentHistogram != null
+                    && currentHistogram.name.equals(baseName + "_bucket")
                     && currentHistogram.labels.equals(customLabels)) {
                     currentHistogram.setCount((int) value);
-                } else if (currentSummary != null && currentSummary.name.equals(baseName)
+
+                } else if (currentSummary != null
+                    && currentSummary.name.equals(baseName)
                     && currentSummary.labels.equals(customLabels)) {
                     currentSummary.setCount((int) value);
+
                 } else if (type != null) {
+                    // If type is known gauge/counter, parse accordingly
                     if (type.equals("gauge")) {
                         metrics.add(new Gauge(name, customLabels, line, value));
                     } else if (type.equals("counter")) {
                         metrics.add(new Counter(name, customLabels, line, value));
                     }
                 }
+
             } else if (labels.containsKey("quantile")) {
+                // Summaries: quantiles
                 if (currentSummary == null
                     || !currentSummary.name.equals(name)
                     || !currentSummary.labels.equals(customLabels)) {
@@ -103,12 +129,15 @@ public class PrometheusTextFormatParser {
                 }
                 double quantile = Double.parseDouble(labels.get("quantile"));
                 currentSummary.addQuantile(quantile, value);
+
             } else {
+                // Plain gauge
                 metrics.add(new Gauge(name, labels, line, value));
             }
         }
         return metrics;
     }
+
 
     /**
      * Method that "removes" Prometheus labels (connected to buckets or summary) and returns just the custom labels
@@ -124,7 +153,6 @@ public class PrometheusTextFormatParser {
         return customLabels;
     }
 
-
     private static String[] parseNameAndLabels(String metricNameAndLabels) {
         int labelStartIndex = metricNameAndLabels.indexOf('{');
         if (labelStartIndex == -1) {
@@ -137,12 +165,15 @@ public class PrometheusTextFormatParser {
 
     private static Map<String, String> parseLabels(String labelString) {
         Map<String, String> labels = new HashMap<>();
-        if (labelString.isEmpty()) return labels;
-        labelString = labelString.substring(1, labelString.length() - 1); // Remove curly braces
+        if (labelString.isEmpty()) {
+            return labels;
+        }
+        // Remove surrounding '{' and '}'
+        labelString = labelString.substring(1, labelString.length() - 1);
         String[] labelPairs = labelString.split(",");
         for (String labelPair : labelPairs) {
             labelPair = labelPair.trim();
-            if (labelPair.isEmpty()) continue;  // Skip empty tokens
+            if (labelPair.isEmpty()) continue;
             String[] keyValue = labelPair.split("=", 2);
             if (keyValue.length < 2) continue;
             String key = keyValue[0].trim();

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
@@ -55,7 +55,7 @@ public class PrometheusTextFormatParserTest {
             "my_histogram_sum 10.0\n" +
             "my_histogram_count 7\n";
         List<Metric> metrics = PrometheusTextFormatParser.parse(data);
-        assertEquals(1, metrics.size());
+        assertEquals(2, metrics.size());
         Histogram hist = (Histogram) metrics.get(0);
         assertEquals(10.0, hist.getSum(), 0.0001);
         assertEquals(7, hist.getCount());
@@ -75,7 +75,7 @@ public class PrometheusTextFormatParserTest {
             "my_summary_count 2\n";
         List<Metric> metrics = PrometheusTextFormatParser.parse(data);
         // Only one summary should be created.
-        assertEquals(1, metrics.size());
+        assertEquals(2, metrics.size());
         Summary summary = (Summary) metrics.get(0);
         assertEquals(7.0, summary.getSum(), 0.0001);
         assertEquals(2, summary.getCount());
@@ -118,5 +118,94 @@ public class PrometheusTextFormatParserTest {
         Metric m = metrics.get(0);
         assertTrue(m instanceof Gauge);
         assertEquals(1.23456789, ((Gauge) m).getValue(), 0.000001);
+    }
+
+    @Test
+    void testParseHugeMixedMetrics() throws IOException {
+        // A single blob containing:
+        // - Gauges
+        // - Counters (with _total suffix)
+        // - Histograms (with buckets, _sum, and _count)
+        // - Summaries (with quantiles, _sum, and _count)
+        // - Various label orders, trailing commas, scientific notation, etc.
+        String data = """
+            # TYPE test_gauge gauge
+            test_gauge 123.456
+    
+            # TYPE test_counter counter
+            test_counter_total{mode="simple"} 777
+            test_counter_total{mode="complex",extra="true",} 888.888e2
+    
+            # TYPE test_histogram histogram
+            test_histogram_bucket{le="0.1",type="speed"} 2
+            test_histogram_bucket{type="speed",le="1.0"} 5
+            test_histogram_bucket{le="+Inf",type="speed"} 9
+            test_histogram_sum{type="speed"} 22.0
+            test_histogram_count{type="speed"} 9
+    
+            # TYPE test_summary summary
+            test_summary{quantile="0.5",app="myapp"} 42
+            test_summary{quantile="0.9",app="myapp"} 84
+            test_summary{quantile="0.9",app="myapp"} 84
+            test_summary_sum{app="myapp"} 139
+            test_summary_count{app="myapp"} 2
+    
+            # TYPE custom_sum_is_gauge gauge
+            custom_sum_is_gauge_sum{label="trailing_comma",} 3.14
+    
+            # Additional lines
+            # TYPE fancy_metric gauge
+            fancy_metric{label1="X", label2="Y"} 456.789
+            """;
+
+        List<Metric> metrics = PrometheusTextFormatParser.parse(data);
+
+        assertEquals(9, metrics.size(), "Expected 7 top-level Metric objects to be parsed");
+
+        // Check we have a histogram with correct sum and count
+        Histogram hist = metrics.stream()
+            .filter(m -> m instanceof Histogram && m.getName().startsWith("test_histogram_bucket"))
+            .map(m -> (Histogram) m)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No histogram named 'test_histogram_bucket' found"));
+
+        // Buckets: 0.1 =>2, 1.0 =>5, +Inf =>9
+        assertEquals(3, hist.getBuckets().size());
+        assertEquals(2, hist.getBuckets().get(0.1), 0.0001);
+        assertEquals(5, hist.getBuckets().get(1.0), 0.0001);
+        assertEquals(9, hist.getBuckets().get(Double.MAX_VALUE), 0.0001);
+        assertEquals(22.0, hist.getSum(), 0.0001);
+        assertEquals(9, hist.getCount());
+
+        // Check summary with two quantiles
+        Summary summ = metrics.stream()
+            .filter(m -> m instanceof Summary && m.getName().equals("test_summary"))
+            .map(m -> (Summary) m)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No summary named 'test_summary' found"));
+
+        assertEquals(2, summ.getQuantiles().size());
+        assertEquals(42, summ.getQuantiles().get(0.5), 0.0001);
+        assertEquals(84, summ.getQuantiles().get(0.9), 0.0001);
+        assertEquals(139, summ.getSum(), 0.0001);
+        assertEquals(2, summ.getCount());
+
+        Gauge customSumGauge = metrics.stream()
+            .filter(m -> m instanceof Gauge && m.getName().equals("custom_sum_is_gauge_sum"))
+            .map(m -> (Gauge) m)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No gauge named 'custom_sum_is_gauge_sum' found"));
+        assertEquals(3.14, customSumGauge.getValue(), 0.0001);
+
+        List<Counter> counters = metrics.stream()
+            .filter(m -> m instanceof Counter && m.getName().equals("test_counter_total"))
+            .map(m -> (Counter) m)
+            .toList();
+        assertEquals(2, counters.size());
+
+        double[] expectedValues = {777.0, 88888.8};
+        for (int i = 0; i < counters.size(); i++) {
+            assertEquals(expectedValues[i], counters.get(i).getValue(), 0.001);
+        }
     }
 }

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
@@ -1,0 +1,106 @@
+package io.skodjob.testframe;
+
+import io.skodjob.testframe.metrics.Counter;
+import io.skodjob.testframe.metrics.Gauge;
+import io.skodjob.testframe.metrics.Histogram;
+import io.skodjob.testframe.metrics.Metric;
+import io.skodjob.testframe.metrics.PrometheusTextFormatParser;
+import io.skodjob.testframe.metrics.Summary;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PrometheusTextFormatParserTest {
+
+    @Test
+    void testParseGaugeMetric() throws IOException {
+        String data = "# TYPE my_gauge gauge\n" +
+            "my_gauge{label=\"value\"} 123.45\n";
+        List<Metric> metrics = PrometheusTextFormatParser.parse(data);
+        assertEquals(1, metrics.size());
+        Metric m = metrics.get(0);
+        assertTrue(m instanceof Gauge);
+        assertEquals(123.45, ((Gauge) m).getValue(), 0.0001);
+        assertEquals("value", m.getLabels().get("label"));
+    }
+
+    @Test
+    void testParseCounterMetric() throws IOException {
+        String data = "# TYPE my_counter counter\n" +
+            "my_counter_total{label=\"cnt\"} 10\n" +
+            "my_counter_count{label=\"cnt\"} 10\n";
+        List<Metric> metrics = PrometheusTextFormatParser.parse(data);
+        assertEquals(2, metrics.size());
+        for (Metric m : metrics) {
+            assertTrue(m instanceof Counter);
+            assertEquals(10, ((Counter) m).getValue(), 0.0001);
+        }
+    }
+
+    @Test
+    void testParseHistogramMetrics() throws IOException {
+        String data = "# TYPE my_histogram histogram\n" +
+            "my_histogram_bucket{le=\"0.1\"} 2\n" +
+            "my_histogram_bucket{le=\"1.0\"} 5\n" +
+            "my_histogram_bucket{le=\"+Inf\"} 7\n" +
+            "my_histogram_sum 10.0\n" +
+            "my_histogram_count 7\n";
+        List<Metric> metrics = PrometheusTextFormatParser.parse(data);
+        assertEquals(1, metrics.size());
+        Histogram hist = (Histogram) metrics.get(0);
+        assertEquals(10.0, hist.getSum(), 0.0001);
+        assertEquals(7, hist.getCount());
+        Map<Double, Double> buckets = hist.getBuckets();
+        assertEquals(3, buckets.size());
+        assertEquals(2, buckets.get(0.1), 0.0001);
+        assertEquals(5, buckets.get(1.0), 0.0001);
+        assertEquals(7, buckets.get(Double.MAX_VALUE), 0.0001);
+    }
+
+    @Test
+    void testParseSummaryMetrics() throws IOException {
+        String data = "# TYPE my_summary summary\n" +
+            "my_summary{quantile=\"0.5\"} 3.0\n" +
+            "my_summary{quantile=\"0.9\"} 4.0\n" +
+            "my_summary_sum 7.0\n" +
+            "my_summary_count 2\n";
+        List<Metric> metrics = PrometheusTextFormatParser.parse(data);
+        // Only one summary should be created.
+        assertEquals(1, metrics.size());
+        Summary summary = (Summary) metrics.get(0);
+        assertEquals(7.0, summary.getSum(), 0.0001);
+        assertEquals(2, summary.getCount());
+        Map<Double, Double> quantiles = summary.getQuantiles();
+        assertEquals(2, quantiles.size());
+        assertEquals(3.0, quantiles.get(0.5), 0.0001);
+        assertEquals(4.0, quantiles.get(0.9), 0.0001);
+    }
+
+    @Test
+    void testInvalidLineSkipped() throws IOException {
+        String data = "invalid_line_without_space";
+        List<Metric> metrics = PrometheusTextFormatParser.parse(data);
+        assertEquals(0, metrics.size());
+    }
+
+    @Test
+    void testParseAllMetrics() throws IOException {
+        String data = "# TYPE jvm_memory_used_bytes gauge\n" +
+            "jvm_memory_used_bytes{area=\"nonheap\",id=\"CodeHeap 'profiled nmethods'\",} 1.635584E7\n" +
+            "jvm_memory_used_bytes{area=\"heap\",id=\"G1 Survivor Space\",} 1981904.0\n" +
+            "jvm_memory_used_bytes{area=\"heap\",id=\"G1 Old Gen\",} 1.76768E7\n" +
+            "jvm_memory_used_bytes{area=\"nonheap\",id=\"Metaspace\",} 4.9460992E7\n" +
+            "jvm_memory_used_bytes{area=\"nonheap\",id=\"CodeHeap 'non-nmethods'\",} 1374848.0\n" +
+            "jvm_memory_used_bytes{area=\"heap\",id=\"G1 Eden Space\",} 2097152.0\n" +
+            "jvm_memory_used_bytes{area=\"nonheap\",id=\"Compressed Class Space\",} 5468744.0\n" +
+            "jvm_memory_used_bytes{area=\"nonheap\",id=\"CodeHeap 'non-profiled nmethods'\",} 4937600.0\n";
+        List<Metric> metrics = PrometheusTextFormatParser.parse(data);
+
+        assertEquals(8, metrics.size());
+    }
+}

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.skodjob.testframe;
 
 import io.skodjob.testframe.metrics.Counter;

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
@@ -110,15 +110,13 @@ public class PrometheusTextFormatParserTest {
     }
 
     @Test
-    void testParseSumWithTrailingComma() throws IOException {
-        String data = "# TYPE strimzi_describe_topics_duration_seconds_sum gauge\n" +
-            "strimzi_describe_topics_duration_seconds_sum{kind=\"KafkaTopic\",namespace=\"co-namespace\"," +
-            "selector=\"strimzi.io/cluster=cluster-5e6e237c\",} 0.864833836\n";
+    void testParseGaugeSumWithTrailingComma() throws IOException {
+        String data = "# TYPE custom_operation_duration_seconds_sum gauge\n" +
+            "custom_operation_duration_seconds_sum{operation=\"write\",source=\"serviceA\",} 1.23456789\n";
         List<Metric> metrics = PrometheusTextFormatParser.parse(data);
-        // The orphaned _sum metric is parsed as a Gauge.
         assertEquals(1, metrics.size());
         Metric m = metrics.get(0);
         assertTrue(m instanceof Gauge);
-        assertEquals(0.864833836, ((Gauge) m).getValue(), 0.000001);
+        assertEquals(1.23456789, ((Gauge) m).getValue(), 0.000001);
     }
 }

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
@@ -107,4 +107,17 @@ public class PrometheusTextFormatParserTest {
 
         assertEquals(8, metrics.size());
     }
+
+    @Test
+    void testParseSumWithTrailingComma() throws IOException {
+        String data = "# TYPE strimzi_describe_topics_duration_seconds_sum gauge\n" +
+            "strimzi_describe_topics_duration_seconds_sum{kind=\"KafkaTopic\",namespace=\"co-namespace\"," +
+            "selector=\"strimzi.io/cluster=cluster-5e6e237c\",} 0.864833836\n";
+        List<Metric> metrics = PrometheusTextFormatParser.parse(data);
+        // The orphaned _sum metric is parsed as a Gauge.
+        assertEquals(1, metrics.size());
+        Metric m = metrics.get(0);
+        assertTrue(m instanceof Gauge);
+        assertEquals(0.864833836, ((Gauge) m).getValue(), 0.000001);
+    }
 }

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
@@ -93,19 +93,20 @@ public class PrometheusTextFormatParserTest {
     }
 
     @Test
-    void testParseAllMetrics() throws IOException {
-        String data = "# TYPE jvm_memory_used_bytes gauge\n" +
-            "jvm_memory_used_bytes{area=\"nonheap\",id=\"CodeHeap 'profiled nmethods'\",} 1.635584E7\n" +
-            "jvm_memory_used_bytes{area=\"heap\",id=\"G1 Survivor Space\",} 1981904.0\n" +
-            "jvm_memory_used_bytes{area=\"heap\",id=\"G1 Old Gen\",} 1.76768E7\n" +
-            "jvm_memory_used_bytes{area=\"nonheap\",id=\"Metaspace\",} 4.9460992E7\n" +
-            "jvm_memory_used_bytes{area=\"nonheap\",id=\"CodeHeap 'non-nmethods'\",} 1374848.0\n" +
-            "jvm_memory_used_bytes{area=\"heap\",id=\"G1 Eden Space\",} 2097152.0\n" +
-            "jvm_memory_used_bytes{area=\"nonheap\",id=\"Compressed Class Space\",} 5468744.0\n" +
-            "jvm_memory_used_bytes{area=\"nonheap\",id=\"CodeHeap 'non-profiled nmethods'\",} 4937600.0\n";
+    void testParseMultipleGaugeMetrics() throws IOException {
+        String data = "# TYPE custom_memory_used_bytes gauge\n" +
+            "custom_memory_used_bytes{type=\"nonheap\",segment=\"segmentA\",} 1000.0\n" +
+            "custom_memory_used_bytes{type=\"heap\",segment=\"segmentB\",} 2000.0\n" +
+            "custom_memory_used_bytes{type=\"heap\",segment=\"segmentC\",} 3000.0\n" +
+            "custom_memory_used_bytes{type=\"nonheap\",segment=\"segmentD\",} 4000.0\n" +
+            "custom_memory_used_bytes{type=\"nonheap\",segment=\"segmentE\",} 5000.0\n" +
+            "custom_memory_used_bytes{type=\"heap\",segment=\"segmentF\",} 6000.0\n" +
+            "custom_memory_used_bytes{type=\"nonheap\",segment=\"segmentG\",} 7000.0\n" +
+            "custom_memory_used_bytes{type=\"nonheap\",segment=\"segmentH\",} 8000.0\n";
         List<Metric> metrics = PrometheusTextFormatParser.parse(data);
 
         assertEquals(8, metrics.size());
+        metrics.forEach(m -> assertTrue(m instanceof Gauge));
     }
 
     @Test


### PR DESCRIPTION
## Description

Currently, we do not support the metrics which has following format:
```
# HELP jvm_memory_used_bytes The amount of used memory
# TYPE jvm_memory_used_bytes gauge
jvm_memory_used_bytes{area="nonheap",id="CodeHeap 'profiled nmethods'",} 1.635584E7
jvm_memory_used_bytes{area="heap",id="G1 Survivor Space",} 1981904.0
jvm_memory_used_bytes{area="heap",id="G1 Old Gen",} 1.76768E7
jvm_memory_used_bytes{area="nonheap",id="Metaspace",} 4.9460992E7
jvm_memory_used_bytes{area="nonheap",id="CodeHeap 'non-nmethods'",} 1374848.0
jvm_memory_used_bytes{area="heap",id="G1 Eden Space",} 2097152.0
jvm_memory_used_bytes{area="nonheap",id="Compressed Class Space",} 5468744.0
jvm_memory_used_bytes{area="nonheap",id="CodeHeap 'non-profiled nmethods'",} 4937600.0
```
`PrometheusTextFormatParser` would only parse one of this metrics even metrics are collected right in 
```java
final String metrics = collectMetrics(podIP, podName);
```
but this piece of line contains a bug:
```
map.put(podName, PrometheusTextFormatParser.parse(metrics));
```
Moreover, I have also added `PrometheusTextFormatParser` tests, which lacks for such class.

## Type of Change


* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
