### PR TITLE
Add replaceResource method to KubeResourceManager

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -482,6 +482,25 @@ public class KubeResourceManager {
     }
 
     /**
+     * Based on {@param resource} and {@param editor} replaces the current resource.
+     * In case that the {@link ResourceType} is not found, the default client is used.
+     *
+     * @param resource  The resource that should be updated.
+     * @param editor    Editor containing all changes that should be propagated to resource
+     * @param <T>       The type of the resource.
+     */
+    public final <T extends HasMetadata> void replaceResource(T resource, Consumer<T> editor) {
+        ResourceType<T> type = findResourceType(resource);
+        if (type != null) {
+            type.replace(resource, editor);
+        } else {
+            T toBeReplaced = client.getClient().resource(resource).get();
+            editor.accept(toBeReplaced);
+            client.getClient().resource(toBeReplaced).update();
+        }
+    }
+
+    /**
      * Waits for a resource condition to be fulfilled.
      *
      * @param resource      The resource to wait for.

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -81,6 +82,18 @@ public class KubeResourceManagerTest {
         assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test4").get());
         KubeResourceManager.get().createOrUpdateResourceWithoutWait(ns);
         assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test4").get());
+    }
+
+    @Test
+    void testReplaceResource() {
+        Namespace ns = new NamespaceBuilder().withNewMetadata().withName("test5").endMetadata().build();
+        KubeResourceManager.get().createResourceWithWait(ns);
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test5").get());
+
+        KubeResourceManager.get().replaceResource(ns,
+            resource -> resource.getMetadata().setLabels(Map.of("my-label", "here")));
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName("test5").get()
+            .getMetadata().getLabels().get("my-label"));
     }
 
     @Test

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
@@ -8,10 +8,10 @@ import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.testframe.annotations.ResourceManager;
 import io.skodjob.testframe.resources.KubeResourceManager;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import io.skodjob.testframe.resources.NamespaceType;
+import org.junit.jupiter.api.*;
+
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,24 +21,43 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public final class KubeResourceManagerIT extends AbstractIT {
     Namespace ns1 = new NamespaceBuilder().withNewMetadata().withName(nsName1).endMetadata().build();
 
-    @BeforeEach
-    void setupEach() {
+    @BeforeAll
+    void setupAll() {
         KubeResourceManager.get().createResourceWithWait(ns1);
     }
 
     @AfterEach
     void afterEach() {
-        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
+        Namespace ns2 = KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get();
+        assertNotNull(ns2);
+        KubeResourceManager.get().deleteResource(false, ns2);
+        assertTrue(isDeleteHandlerCalled.get());
+    }
+
+    @AfterAll
+    void afterAll() {
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName1).get());
         KubeResourceManager.get().deleteResources();
     }
 
+
     @Test
     void createResource() {
-        KubeResourceManager.get().createResourceWithWait(
-            new NamespaceBuilder().withNewMetadata().withName("test2").endMetadata().build());
+        Namespace ns2 = new NamespaceBuilder().withNewMetadata().withName(nsName2).endMetadata().build();
+        KubeResourceManager.get().createResourceWithWait(ns2);
         assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName1).get());
         assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
-        KubeResourceManager.get().deleteResource(false, ns1);
-        assertTrue(isDeleteHandlerCalled.get());
+    }
+
+    @Test
+    void replaceResource() {
+        Namespace ns = new NamespaceBuilder().withNewMetadata().withName(nsName2).endMetadata().build();
+        KubeResourceManager.get().createResourceWithWait(ns);
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
+
+        KubeResourceManager.get().replaceResource(ns,
+            resource -> resource.getMetadata().setLabels(Map.of("my-label", "here")));
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get()
+            .getMetadata().getLabels().get("my-label"));
     }
 }

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
@@ -8,8 +8,11 @@ import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.testframe.annotations.ResourceManager;
 import io.skodjob.testframe.resources.KubeResourceManager;
-import io.skodjob.testframe.resources.NamespaceType;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.util.Map;
 

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
@@ -8,11 +8,8 @@ import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.testframe.annotations.ResourceManager;
 import io.skodjob.testframe.resources.KubeResourceManager;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import io.skodjob.testframe.resources.NamespaceType;
+import org.junit.jupiter.api.*;
 
 import java.util.Map;
 

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
@@ -8,10 +8,10 @@ import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.skodjob.testframe.annotations.ResourceManager;
 import io.skodjob.testframe.resources.KubeResourceManager;
-import io.skodjob.testframe.resources.NamespaceType;
-import org.junit.jupiter.api.*;
-
-import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,43 +21,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public final class KubeResourceManagerIT extends AbstractIT {
     Namespace ns1 = new NamespaceBuilder().withNewMetadata().withName(nsName1).endMetadata().build();
 
-    @BeforeAll
-    void setupAll() {
+    @BeforeEach
+    void setupEach() {
         KubeResourceManager.get().createResourceWithWait(ns1);
     }
 
     @AfterEach
     void afterEach() {
-        Namespace ns2 = KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get();
-        assertNotNull(ns2);
-        KubeResourceManager.get().deleteResource(false, ns2);
-        assertTrue(isDeleteHandlerCalled.get());
-    }
-
-    @AfterAll
-    void afterAll() {
-        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName1).get());
+        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
         KubeResourceManager.get().deleteResources();
     }
 
-
     @Test
     void createResource() {
-        Namespace ns2 = new NamespaceBuilder().withNewMetadata().withName(nsName2).endMetadata().build();
-        KubeResourceManager.get().createResourceWithWait(ns2);
+        KubeResourceManager.get().createResourceWithWait(
+            new NamespaceBuilder().withNewMetadata().withName("test2").endMetadata().build());
         assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName1).get());
         assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
-    }
-
-    @Test
-    void replaceResource() {
-        Namespace ns = new NamespaceBuilder().withNewMetadata().withName(nsName2).endMetadata().build();
-        KubeResourceManager.get().createResourceWithWait(ns);
-        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
-
-        KubeResourceManager.get().replaceResource(ns,
-            resource -> resource.getMetadata().setLabels(Map.of("my-label", "here")));
-        assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get()
-            .getMetadata().getLabels().get("my-label"));
+        KubeResourceManager.get().deleteResource(false, ns1);
+        assertTrue(isDeleteHandlerCalled.get());
     }
 }


### PR DESCRIPTION
## Description

This PR adds simple method `replaceResource` which allow us to replace the object easier -> using the Consumer.
Also, until now we didn't use the `replace` method in each resource type, that's where this method comes handy.

## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit/integration tests pass locally with my changes
