### PR TITLE
Remove antipattern of TestFrameConstants interface and use final class

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/TestFrameConstants.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/TestFrameConstants.java
@@ -9,66 +9,66 @@ import java.time.Duration;
 /**
  * Constants used in the test framework.
  */
-public interface TestFrameConstants {
+public final class TestFrameConstants {
 
     /**
      * Global poll interval in milliseconds (long).
      */
-    long GLOBAL_POLL_INTERVAL_LONG = Duration.ofSeconds(15).toMillis();
+    public static final long GLOBAL_POLL_INTERVAL_LONG = Duration.ofSeconds(15).toMillis();
 
     /**
      * Global poll interval in milliseconds (medium).
      */
-    long GLOBAL_POLL_INTERVAL_MEDIUM = Duration.ofSeconds(10).toMillis();
+    public static final long GLOBAL_POLL_INTERVAL_MEDIUM = Duration.ofSeconds(10).toMillis();
 
     /**
      * Global poll interval in milliseconds (short).
      */
-    long GLOBAL_POLL_INTERVAL_SHORT = Duration.ofSeconds(5).toMillis();
+    public static final long GLOBAL_POLL_INTERVAL_SHORT = Duration.ofSeconds(5).toMillis();
 
     /**
      * Global poll interval in milliseconds (1 second).
      */
-    long GLOBAL_POLL_INTERVAL_1_SEC = Duration.ofSeconds(1).toMillis();
+    public static final long GLOBAL_POLL_INTERVAL_1_SEC = Duration.ofSeconds(1).toMillis();
 
     /**
      * Global timeout in milliseconds (medium).
      */
-    long GLOBAL_TIMEOUT_MEDIUM = Duration.ofMinutes(5).toMillis();
+    public static final long GLOBAL_TIMEOUT_MEDIUM = Duration.ofMinutes(5).toMillis();
 
 
     /**
      * Global timeout in milliseconds.
      */
-    long GLOBAL_TIMEOUT = Duration.ofMinutes(10).toMillis();
+    public static final long GLOBAL_TIMEOUT = Duration.ofMinutes(10).toMillis();
 
     /**
      * Global timeout in milliseconds.
      */
-    long GLOBAL_TIMEOUT_SHORT = Duration.ofMinutes(3).toMillis();
+    public static final long GLOBAL_TIMEOUT_SHORT = Duration.ofMinutes(3).toMillis();
 
     /**
      * Stability timeout in milliseconds
      */
-    long GLOBAL_STABILITY_TIME = Duration.ofMinutes(1).toMillis();
+    public static final long GLOBAL_STABILITY_TIME = Duration.ofMinutes(1).toMillis();
 
     /**
      * CA validity delay
      */
-    long CA_CERT_VALIDITY_DELAY = 10;
+    public static final long CA_CERT_VALIDITY_DELAY = 10;
 
     /**
      * Poll interval for resource readiness
      */
-    long POLL_INTERVAL_FOR_RESOURCE_READINESS = Duration.ofSeconds(1).toMillis();
+    public static final long POLL_INTERVAL_FOR_RESOURCE_READINESS = Duration.ofSeconds(1).toMillis();
 
     /**
      * OpenShift client type.
      */
-    String OPENSHIFT_CLIENT = "oc";
+    public static final String OPENSHIFT_CLIENT = "oc";
 
     /**
      * Kubernetes client type.
      */
-    String KUBERNETES_CLIENT = "kubectl";
+    public static final String KUBERNETES_CLIENT = "kubectl";
 }

--- a/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/environment/TestEnvironmentVariables.java
@@ -34,7 +34,7 @@ public class TestEnvironmentVariables {
     private final Map<String, String> values = new HashMap<>();
     private Map<String, Object> yamlData = new HashMap<>();
     private final String configFilePath;
-    private final String configFilePathEnv = "ENV_FILE";
+    private static final String CONFIG_FILE_PATH_ENV = "ENV_FILE";
 
     /**
      * {@link TestEnvironmentVariables} object initialization, where the config file is loaded to {@link #yamlData}
@@ -52,7 +52,7 @@ public class TestEnvironmentVariables {
      */
     public TestEnvironmentVariables(Map<String, String> envMap) {
         this.envMap = envMap;
-        this.configFilePath = envMap.getOrDefault(configFilePathEnv,
+        this.configFilePath = envMap.getOrDefault(CONFIG_FILE_PATH_ENV,
             Paths.get(System.getProperty("user.dir"), "config.yaml").toAbsolutePath().toString());
         this.yamlData = loadConfigurationFile();
     }
@@ -98,7 +98,7 @@ public class TestEnvironmentVariables {
     }
 
     /**
-     * Method that loads configuration file - either from specified path by {@link #configFilePathEnv} or from
+     * Method that loads configuration file - either from specified path by {@link #CONFIG_FILE_PATH_ENV} or from
      * the default path (in the `config.yaml` file on the `user.dir` path).
      * If the file doesn't exist, the info log is printed and empty Map is returned.
      *

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @EnableKubernetesMockClient(crud = true)
 @ResourceManager
 @TestVisualSeparator
-public class KubeResourceManagerTest {
+class KubeResourceManagerTest {
     private KubernetesClient kubernetesClient;
     private KubernetesMockServer server;
 

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/UtilsTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/UtilsTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @EnableKubernetesMockClient(crud = true)
 @ResourceManager
 @TestVisualSeparator
-public class UtilsTest {
+class UtilsTest {
     private KubernetesClient kubernetesClient;
     private KubernetesMockServer server;
 

--- a/test-frame-common/src/test/java/io/skodjob/testframe/environment/TestEnvironmentVariablesTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/environment/TestEnvironmentVariablesTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class TestEnvironmentVariablesTest {
+class TestEnvironmentVariablesTest {
 
     @Test
     void testGetEnvVariablesCorrectly() {

--- a/test-frame-common/src/test/java/io/skodjob/testframe/security/CertAndKeyBuilderTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/security/CertAndKeyBuilderTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CertAndKeyBuilderTest {
+class CertAndKeyBuilderTest {
     static final String ROOT_CA = "C=COM, L=Boston, O=Example, CN=ExampleRootCA";
     static final String INTERMEDIATE_CA = "C=COM, L=Boston, O=Example, CN=ExampleIntermediateCA";
     static final String END_SUBJECT = "C=COM, L=Boston, O=Example, CN=end-app.example.io";

--- a/test-frame-common/src/test/java/io/skodjob/testframe/security/SecurityUtilsTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/security/SecurityUtilsTest.java
@@ -17,7 +17,7 @@ import java.nio.file.Paths;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class SecurityUtilsTest {
+class SecurityUtilsTest {
     static final String ROOT_CA = "C=COM, L=Boston, O=Example, CN=ExampleRootCA";
     static final String INTERMEDIATE_CA = "C=COM, L=Boston, O=Example, CN=ExampleIntermediateCA";
     static final String END_SUBJECT = "C=COM, L=Boston, O=Example, CN=end-app.example.io";

--- a/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorBuilderTest.java
+++ b/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorBuilderTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @TestVisualSeparator
-public class LogCollectorBuilderTest {
+final class LogCollectorBuilderTest {
 
     @Test
     void testPassingPodAndPodsAsResourcesToLogCollectorBuilder() {

--- a/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorIT.java
+++ b/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorIT.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.when;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestVisualSeparator
 @SuppressWarnings("unchecked")
-public class LogCollectorIT {
+final class LogCollectorIT {
 
     private KubeClient mockClient;
     private KubeCmdClient mockCmdClient;

--- a/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorUtilsTest.java
+++ b/test-frame-log-collector/src/test/java/io/skodjob/testframe/LogCollectorUtilsTest.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @TestVisualSeparator
-public class LogCollectorUtilsTest {
+final class LogCollectorUtilsTest {
 
     @Test
     void testYamlFileNameForResource() {

--- a/test-frame-log-collector/src/test/java/io/skodjob/testframe/MustGatherHandlerTest.java
+++ b/test-frame-log-collector/src/test/java/io/skodjob/testframe/MustGatherHandlerTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @ExtendWith(TestListener.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @MustGather(config = MustGatherTestSupplier.class)
-public class MustGatherHandlerTest {
+final class MustGatherHandlerTest {
 
     @Test
     @Order(1)

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorMockTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorMockTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
-public class MetricsCollectorMockTest {
+final class MetricsCollectorMockTest {
 
     private KubernetesClient mockClient;
     private KubeCmdClient mockCmdClient;

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorTest.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class MetricsCollectorTest {
+final class MetricsCollectorTest {
 
     private MetricsCollector metricsCollector;
 

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/PrometheusTextFormatParserTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class PrometheusTextFormatParserTest {
+final class PrometheusTextFormatParserTest {
 
     @Test
     void testParseGaugeMetric() throws IOException {

--- a/test-frame-openshift/src/test/java/io/skodjob/testframe/olm/OperatorSdkRunBuilderTest.java
+++ b/test-frame-openshift/src/test/java/io/skodjob/testframe/olm/OperatorSdkRunBuilderTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class OperatorSdkRunBuilderTest {
+final class OperatorSdkRunBuilderTest {
 
     @Test
     void testBuilder() {

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeClientIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeClientIT.java
@@ -15,7 +15,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public final class KubeClientIT extends AbstractIT {
+final class KubeClientIT extends AbstractIT {
 
     @Test
     void testCreateResourcesFromYaml() throws IOException {

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ResourceManager(asyncDeletion = false)
-public final class KubeResourceManagerCleanerIT extends AbstractIT {
+final class KubeResourceManagerCleanerIT extends AbstractIT {
 
     @BeforeAll
     void setupAll() {

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ResourceManager(cleanResources = false) // override default behavior and do not clean resources
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public final class KubeResourceManagerIT extends AbstractIT {
+final class KubeResourceManagerIT extends AbstractIT {
     Namespace ns1 = new NamespaceBuilder().withNewMetadata().withName(nsName1).endMetadata().build();
 
     @BeforeEach

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/LogCollectorIT.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public final class LogCollectorIT extends AbstractIT {
+final class LogCollectorIT extends AbstractIT {
     private final String folderRoot = "/tmp/log-collector-examples";
     private final String[] resourcesToBeCollected = new String[] {"secret", "configmap", "deployment"};
     private final LogCollector logCollector = new LogCollectorBuilder()

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MetricsCollectorIT.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public final class MetricsCollectorIT extends AbstractIT {
+final class MetricsCollectorIT extends AbstractIT {
 
     @Test
     void testCollectMetrics() throws IOException {

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MustGatherIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/MustGatherIT.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @ExtendWith(TestListener.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @MustGather(config = MustGatherSupplierImpl.class)
-public final class MustGatherIT extends AbstractIT {
+final class MustGatherIT extends AbstractIT {
 
     @Test
     @Order(1)


### PR DESCRIPTION
## Description

1. Remove constants interface antipattern
2. Remove public modifier for test classes
3. Add final modifier for test classes


## Type of Change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
