### PR TITLE
Add replaceResourceWithRetries in case of conflicts

### DIFF
--- a/test-frame-common/pom.xml
+++ b/test-frame-common/pom.xml
@@ -86,6 +86,11 @@
             <artifactId>openshift-model-operatorhub</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
         </dependency>


### PR DESCRIPTION
## Description

This PR adds `replaceResourceWithRetries` method which retries the `replaceResource` for specified number of times (or default 3) - in case that there is conflict with the object that we are applying and the one available in Kube. That can happen when some operator for example changes some of the field of the resource and we don't have this update when we are doing the `get()` request.
In case that there is something else then conflict, it throws `RuntimeException`.

## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit/integration tests pass locally with my changes
