### PR TITLE
Fix isReady and isDeleted methods in SecretType

### DIFF
--- a/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/SecretType.java
+++ b/test-frame-kubernetes/src/main/java/io/skodjob/testframe/resources/SecretType.java
@@ -96,7 +96,7 @@ public class SecretType implements ResourceType<Secret> {
      */
     @Override
     public boolean isReady(Secret resource) {
-        return false;
+        return resource != null;
     }
 
     /**
@@ -107,6 +107,6 @@ public class SecretType implements ResourceType<Secret> {
      */
     @Override
     public boolean isDeleted(Secret resource) {
-        return false;
+        return resource == null;
     }
 }


### PR DESCRIPTION
## Description

This PR fixes an issue with `isReady` and `isDeleted` methods in `SecretType` that always return `false`.

## Type of Change

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit/integration tests pass locally with my changes
