### PR TITLE
Fix issue with testGetKubeClientFallbackThrowsWhenNull

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -92,7 +92,7 @@ public final class KubeResourceManager {
         TestFrameEnv.CLUSTER_CONFIGS;
     private String storeYamlPath;
 
-    private final Map<String, ClusterContext> clientCache = new ConcurrentHashMap<>();
+    private final Map<String, ClusterContext<? extends KubeCmdClient<?>>> clientCache = new ConcurrentHashMap<>();
     private static final ThreadLocal<String> CURRENT_CLUSTER_CONTEXT = ThreadLocal.withInitial(() ->
         TestFrameConstants.DEFAULT_CONTEXT_NAME);
     private static final ThreadLocal<ExtensionContext> TEST_CONTEXT = new ThreadLocal<>();
@@ -163,7 +163,7 @@ public final class KubeResourceManager {
      * @param id id of cluster
      * @return context
      */
-    private ClusterContext clusterContext(String id) {
+    private ClusterContext<? extends KubeCmdClient<?>> clusterContext(String id) {
         return clientCache.computeIfAbsent(id, cid -> {
             TestEnvironmentVariables.ClusterConfig c = CLUSTER_CONFIGS.get(cid);
             if (c == null) {
@@ -191,7 +191,7 @@ public final class KubeResourceManager {
      *
      * @return context
      */
-    private ClusterContext clusterContext() {
+    private ClusterContext<? extends KubeCmdClient<?>>clusterContext() {
         return clusterContext(CURRENT_CLUSTER_CONTEXT.get());
     }
 

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -179,10 +179,13 @@ public final class KubeResourceManager {
                 kube = new KubeClient();
             }
 
-            KubeCmdClient<?> cmd = TestFrameEnv.CLIENT_TYPE.equals(TestFrameConstants.KUBERNETES_CLIENT)
-                ? new Kubectl(kube.getKubeconfigPath())
-                : new Oc(kube.getKubeconfigPath());
-            return new ClusterContext(kube, cmd);
+            if (TestFrameEnv.CLIENT_TYPE.equals(TestFrameConstants.KUBERNETES_CLIENT)) {
+                Kubectl kubectl = new Kubectl(kube.getKubeconfigPath());
+                return new ClusterContext<>(kube, kubectl);
+            } else {
+                Oc oc = new Oc(kube.getKubeconfigPath());
+                return new ClusterContext<>(kube, oc);
+            }
         });
     }
 
@@ -191,7 +194,7 @@ public final class KubeResourceManager {
      *
      * @return context
      */
-    private ClusterContext<? extends KubeCmdClient<?>>clusterContext() {
+    private ClusterContext<? extends KubeCmdClient<?>> clusterContext() {
         return clusterContext(CURRENT_CLUSTER_CONTEXT.get());
     }
 

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -111,8 +111,7 @@ public final class KubeResourceManager {
      * @param kubeClient kube client
      * @param cmdClient  cmd client
      */
-    private record ClusterContext(KubeClient kubeClient, KubeCmdClient<?> cmdClient) {
-    }
+    private record ClusterContext<K extends KubeCmdClient<K>>(KubeClient kubeClient, K cmdClient) { }
 
     private KubeResourceManager() {
         // Private constructor
@@ -210,10 +209,11 @@ public final class KubeResourceManager {
     /**
      * Returns kube cmd client for current context
      *
+     * @param <K> Type extending {@link KubeCmdClient}
      * @return kube cmd client
      */
-    public KubeCmdClient<?> kubeCmdClient() {
-        return clusterContext().cmdClient;
+    public <K extends KubeCmdClient<K>> K kubeCmdClient() {
+        return (K) clusterContext().cmdClient;
     }
 
     /**

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
@@ -266,7 +266,8 @@ class KubeResourceManagerTest {
     void testUseContextThrowsExceptionWhenContextMissing() {
         String nonExistingContext = "non-existing-context";
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> KubeResourceManager.get().useContext(nonExistingContext));
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> KubeResourceManager.get().useContext(nonExistingContext));
 
         assertTrue(ex.getMessage().contains("Unknown context '" + nonExistingContext + "'"),
             "Exception message should mention the unknown context");

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
@@ -263,6 +263,16 @@ class KubeResourceManagerTest {
     }
 
     @Test
+    void testUseContextThrowsExceptionWhenContextMissing() {
+        String nonExistingContext = "non-existing-context";
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> KubeResourceManager.get().useContext(nonExistingContext));
+
+        assertTrue(ex.getMessage().contains("Unknown context '" + nonExistingContext + "'"),
+            "Exception message should mention the unknown context");
+    }
+
+    @Test
     void testListPrefixedDeployments() {
         KubeResourceManager.get().createResourceWithoutWait(
             new DeploymentBuilder().withNewMetadata()

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -215,14 +215,14 @@ public class MetricsCollector {
         return kubeClient;
     }
 
-    synchronized KubeCmdClient<?> getKubeCmdClient() {
+    synchronized <K extends KubeCmdClient<K>> K getKubeCmdClient() {
         if (kubeCmdClient == null) {
             kubeCmdClient = KubeResourceManager.get().kubeCmdClient();
             if (kubeCmdClient == null) {
                 throw new IllegalStateException("KubeCmdClient is not available");
             }
         }
-        return kubeCmdClient;
+        return (K) kubeCmdClient;
     }
 
     /**

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -205,7 +205,7 @@ public class MetricsCollector {
         this.exec = exec;
     }
 
-    private synchronized KubernetesClient getKubeClient() {
+    synchronized KubernetesClient getKubeClient() {
         if (kubeClient == null) {
             kubeClient = KubeResourceManager.get().kubeClient().getClient();
             if (kubeClient == null) {
@@ -215,7 +215,7 @@ public class MetricsCollector {
         return kubeClient;
     }
 
-    private synchronized KubeCmdClient<?> getKubeCmdClient() {
+    synchronized KubeCmdClient<?> getKubeCmdClient() {
         if (kubeCmdClient == null) {
             kubeCmdClient = KubeResourceManager.get().kubeCmdClient();
             if (kubeCmdClient == null) {

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorMockTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorMockTest.java
@@ -413,7 +413,7 @@ final class MetricsCollectorMockTest {
             when(kubeCmdClient.getClient()).thenReturn(null);
 
             // Then when we try to collect metrics, it should trigger fallback and fail
-            assertThrows(IllegalStateException.class, () -> collector.collectMetricsFromPodsWithoutWait());
+            assertThrows(IllegalStateException.class, collector::collectMetricsFromPodsWithoutWait);
         }
     }
 
@@ -433,7 +433,7 @@ final class MetricsCollectorMockTest {
             // Simulate kubeCmdClient() returns null
             when(resourceManager.kubeCmdClient()).thenReturn(null);
 
-            assertThrows(IllegalStateException.class, () -> collector.getKubeCmdClient());
+            assertThrows(IllegalStateException.class, collector::getKubeCmdClient);
         }
     }
 }

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorMockTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorMockTest.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.skodjob.testframe.clients.KubeClient;
 import io.skodjob.testframe.clients.cmdClient.KubeCmdClient;
 import io.skodjob.testframe.clients.cmdClient.Kubectl;
 import io.skodjob.testframe.exceptions.IncompleteMetricsException;
@@ -391,5 +392,48 @@ final class MetricsCollectorMockTest {
         assertEquals(dummyData, copy.getCollectedData());
         assertEquals(mockExec, copy.getExec());
         assertNotNull(copy.getComponent());
+    }
+
+    @Test
+    void testGetKubeClientFallbackThrowsWhenNoClientAvailable() {
+        final MetricsCollector collector = new MetricsCollector.Builder()
+            .withNamespaceName("namespace")
+            .withScraperPodName("scraperPod")
+            .withComponent(new MetricsCollectorTest.DummyMetricsComponent())
+            .build();
+
+        // Mock KubeResourceManager.get() -> .kubeClient() -> .getClient()
+        try (MockedStatic<KubeResourceManager> mockedStatic = mockStatic(KubeResourceManager.class)) {
+            final KubeResourceManager resourceManager = mock(KubeResourceManager.class);
+            when(KubeResourceManager.get()).thenReturn(resourceManager);
+
+            // Simulate kubeClient().getClient() returning null
+            final KubeClient kubeCmdClient = mock(KubeClient.class);
+            when(resourceManager.kubeClient()).thenReturn(kubeCmdClient);
+            when(kubeCmdClient.getClient()).thenReturn(null);
+
+            // Then when we try to collect metrics, it should trigger fallback and fail
+            assertThrows(IllegalStateException.class, () -> collector.collectMetricsFromPodsWithoutWait());
+        }
+    }
+
+    @Test
+    void testGetKubeCmdClientFallbackThrowsWhenNoClientAvailable() {
+        final MetricsCollector collector = new MetricsCollector.Builder()
+            .withNamespaceName("namespace")
+            .withScraperPodName("scraperPod")
+            .withComponent(new MetricsCollectorTest.DummyMetricsComponent())
+            .build();
+
+        // Don't inject kubeCmdClient manually
+        try (MockedStatic<KubeResourceManager> mockedStatic = mockStatic(KubeResourceManager.class)) {
+            final KubeResourceManager resourceManager = mock(KubeResourceManager.class);
+            when(KubeResourceManager.get()).thenReturn(resourceManager);
+
+            // Simulate kubeCmdClient() returns null
+            when(resourceManager.kubeCmdClient()).thenReturn(null);
+
+            assertThrows(IllegalStateException.class, () -> collector.getKubeCmdClient());
+        }
     }
 }

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.spy;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.skodjob.testframe.exceptions.IncompleteMetricsException;
 import io.skodjob.testframe.exceptions.MetricsCollectionException;
 import io.skodjob.testframe.exceptions.NoPodsFoundException;
@@ -117,20 +116,6 @@ final class MetricsCollectorTest {
 
         assertEquals("quay.io/curl/curl:7.85", collector.getScraperPodImage());
         assertTrue(collector.getDeployScraperPod());
-    }
-
-    @Test
-    void testGetKubeClientFallbackThrowsWhenNull() {
-        MetricsCollector collector = new MetricsCollector.Builder()
-            .withNamespaceName("namespace")
-            .withScraperPodName("scraperPod")
-            .withComponent(new DummyMetricsComponent())
-            .build();
-
-        // Don’t inject kubeClient, force fallback
-        assertThrows(KubernetesClientException.class, () -> {
-            collector.collectMetricsFromPodsWithoutWait(); // triggers internal call
-        });
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR fixes a problem with testGetKubeClientFallbackThrowsWhenNull test case, i.e.,
```java
[ERROR] io.skodjob.testframe.MetricsCollectorTest.testGetKubeClientFallbackThrowsWhenNull -- Time elapsed: 1.735 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Expected io.fabric8.kubernetes.client.KubernetesClientException to be thrown, but nothing was thrown.
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
        at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:73)
        at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:35)
        at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3128)
        at io.skodjob.testframe.MetricsCollectorTest.testGetKubeClientFallbackThrowsWhenNull(MetricsCollectorTest.java:131)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```
Now it should work.

## Type of Change

* Bug fix (non-breaking change which fixes an issue)
* Update (Update version or update existing automation)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
