### PR TITLE
Add `deleteResourceWithoutWait` and other encapsulations of the methods

### DIFF
--- a/test-frame-common/pom.xml
+++ b/test-frame-common/pom.xml
@@ -91,6 +91,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
         </dependency>

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -559,10 +559,9 @@ public final class KubeResourceManager {
     }
 
     /**
-     * Deletes resources.
+     * @deprecated as of release 0.13.0, use {@link #deleteResourceWithAsyncWait(HasMetadata[])} instead.
      *
-     * IMPORTANT: This method is now deprecated.
-     * You should use {@link #deleteResourceWithAsyncWait(HasMetadata[])} instead.
+     * Deletes resources.
      *
      * @param resources The resources to delete.
      * @param <T>       The type of the resources.
@@ -574,10 +573,9 @@ public final class KubeResourceManager {
     }
 
     /**
-     * Deletes resources.
+     * @deprecated as of release 0.13.0, use {@link #deleteResourceWithWait(HasMetadata[])} instead.
      *
-     * IMPORTANT: This method is now deprecated.
-     * You should use {@link #deleteResourceWithWait(HasMetadata[])} instead.
+     * Deletes resources.
      *
      * @param async     Enables async deletion
      * @param resources The resources to delete.

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -532,7 +532,7 @@ public final class KubeResourceManager {
      * @param <T>           The type of the resources.
      */
     @SafeVarargs
-    public final <T extends HasMetadata> void deleteResourceWithAsyncWait(T... resources) {
+    public final <T extends HasMetadata> void deleteResourceAsyncWait(T... resources) {
         deleteResource(true, true, resources);
     }
 
@@ -559,7 +559,7 @@ public final class KubeResourceManager {
     }
 
     /**
-     * @deprecated as of release 0.13.0, use {@link #deleteResourceWithAsyncWait(HasMetadata[])} instead.
+     * @deprecated as of release 0.13.0, use {@link #deleteResourceAsyncWait(HasMetadata[])} instead.
      *
      * Deletes resources.
      *

--- a/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/resources/KubeResourceManager.java
@@ -306,7 +306,7 @@ public final class KubeResourceManager {
         STORED_RESOURCES
             .computeIfAbsent(CURRENT_CLUSTER_CONTEXT.get(), c -> new ConcurrentHashMap<>())
             .computeIfAbsent(getTestContext().getDisplayName(), t -> new Stack<>())
-            .push(new ResourceItem<>(() -> deleteResource(resource), resource));
+            .push(new ResourceItem<>(() -> deleteResourceWithWait(resource), resource));
     }
 
     /**

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/KubeResourceManagerTest.java
@@ -255,7 +255,7 @@ class KubeResourceManagerTest {
 
         try (var ignored = KubeResourceManager.get().useContext(TestFrameConstants.DEFAULT_CONTEXT_NAME)) {
             assertTrue(KubeResourceManager.get().kubeClient().namespaceExists("test-ns-2"));
-            KubeResourceManager.get().deleteResource(sa);
+            KubeResourceManager.get().deleteResourceWithWait(sa);
         }
 
         assertNull(KubeResourceManager.get().kubeClient().getClient()

--- a/test-frame-common/src/test/java/io/skodjob/testframe/resources/KubeResourceManagerMockTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/resources/KubeResourceManagerMockTest.java
@@ -69,7 +69,7 @@ public class KubeResourceManagerMockTest {
             return null;
         }).when(kubeResourceManager).decideDeleteWaitAsync(anyList(), anyBoolean(), any());
 
-        kubeResourceManager.deleteResourceWithAsyncWait(myNamespace);
+        kubeResourceManager.deleteResourceAsyncWait(myNamespace);
 
         assertTrue(asyncWaitTriggered.get());
     }

--- a/test-frame-common/src/test/java/io/skodjob/testframe/resources/KubeResourceManagerMockTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/resources/KubeResourceManagerMockTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe.resources;
+
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+public class KubeResourceManagerMockTest {
+    @Test
+    void testDeleteResourceWithWait() {
+        AtomicBoolean deletionWaitWasCalled = new AtomicBoolean(false);
+        KubeResourceManager kubeResourceManager = spy(KubeResourceManager.class);
+        Namespace myNamespace = new NamespaceBuilder().withNewMetadata().withName("my-namespace").endMetadata().build();
+
+        doAnswer(invocation -> {
+            deletionWaitWasCalled.set(true);
+            return true;
+        }).when(kubeResourceManager).waitResourceCondition(any(), ArgumentMatchers.eq(ResourceCondition.deletion()));
+
+        kubeResourceManager.deleteResourceWithWait(myNamespace);
+
+        assertTrue(deletionWaitWasCalled.get());
+    }
+
+    @Test
+    void testDeleteResourceWithWaitAsync() {
+        KubeResourceManager kubeResourceManager = spy(KubeResourceManager.class);
+        AtomicBoolean asyncWaitTriggered = new AtomicBoolean(false);
+        Namespace myNamespace = new NamespaceBuilder().withNewMetadata().withName("my-namespace").endMetadata().build();
+
+        doAnswer(invocation -> {
+            boolean async = invocation.getArgument(1);
+
+            if (async) {
+                asyncWaitTriggered.set(true);
+            }
+
+            // Simulate the same logic if needed
+            return null;
+        }).when(kubeResourceManager).decideDeleteWaitAsync(anyList(), anyBoolean(), any());
+
+        kubeResourceManager.deleteResourceWithAsyncWait(myNamespace);
+
+        assertTrue(asyncWaitTriggered.get());
+    }
+
+    @Test
+    void testDeleteResourceWithoutWait() {
+        AtomicBoolean deletionWaitWasCalled = new AtomicBoolean(false);
+        KubeResourceManager kubeResourceManager = spy(KubeResourceManager.class);
+        Namespace myNamespace = new NamespaceBuilder().withNewMetadata().withName("my-namespace").endMetadata().build();
+
+        doAnswer(invocation -> {
+            deletionWaitWasCalled.set(true);
+            return true;
+        }).when(kubeResourceManager).waitResourceCondition(any(), eq(ResourceCondition.deletion()));
+
+        kubeResourceManager.deleteResourceWithoutWait(myNamespace);
+
+        assertFalse(deletionWaitWasCalled.get());
+    }
+}

--- a/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
+++ b/test-frame-metrics-collector/src/main/java/io/skodjob/testframe/MetricsCollector.java
@@ -415,7 +415,7 @@ public class MetricsCollector {
      * Delete own scraper pod
      */
     private void deleteScraperPod() {
-        KubeResourceManager.get().deleteResource(
+        KubeResourceManager.get().deleteResourceWithWait(
             new PodBuilder()
                 .withNewMetadata()
                     .withName(this.scraperPodName)

--- a/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorMockTest.java
+++ b/test-frame-metrics-collector/src/test/java/io/skodjob/testframe/MetricsCollectorMockTest.java
@@ -276,7 +276,7 @@ final class MetricsCollectorMockTest {
 
             // Assert: verify both deploy and delete were triggered
             verify(resourceManagerMock).createResourceWithWait(any(Pod.class));
-            verify(resourceManagerMock).deleteResource(any(Pod.class));
+            verify(resourceManagerMock).deleteResourceWithWait(any(Pod.class));
         }
     }
 

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerIT.java
@@ -38,7 +38,7 @@ final class KubeResourceManagerIT extends AbstractIT {
             new NamespaceBuilder().withNewMetadata().withName("test2").endMetadata().build());
         assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName1).get());
         assertNotNull(KubeResourceManager.get().kubeClient().getClient().namespaces().withName(nsName2).get());
-        KubeResourceManager.get().deleteResource(false, ns1);
+        KubeResourceManager.get().deleteResourceWithWait(ns1);
         assertTrue(isDeleteHandlerCalled.get());
     }
 }


### PR DESCRIPTION
## Description

This PR adds `deleteResourceWithoutWait` and other encapsulations:

- `deleteResourceWithAsyncWait`
- `deleteResourceWithWait`
- `deleteResourceWithoutWait`

Which follows the methods for `createOrUpdateResource...`.
It also depricates `deleteResource()` methods, as the encapsulated ones should be really used.

## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
