### PR TITLE
added new image utils method to update the image name as well

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/ImageUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/ImageUtils.java
@@ -107,7 +107,8 @@ public final class ImageUtils {
     }
 
     /**
-     * Method that, for specified {@param image}, replaces the registry, organization, imageName and tag, based on the parameters.
+     * Method that, for specified {@param image}, replaces the registry, organization, imageName and tag,
+     * based on the parameters.
      *
      * @param image the image
      * @param newRegistry the new registry
@@ -116,7 +117,8 @@ public final class ImageUtils {
      * @param newTag the new tag
      * @return the string
      */
-    public static String changeRegistryOrgImageAndTag(String image, String newRegistry, String newOrg, String newImageName, String newTag) {
+    public static String changeRegistryOrgImageAndTag(String image, String newRegistry, String newOrg,
+                                                      String newImageName, String newTag) {
         Matcher m = IMAGE_PATTERN_FULL_PATH.matcher(image);
 
         if (m.find()) {

--- a/test-frame-common/src/main/java/io/skodjob/testframe/utils/ImageUtils.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/utils/ImageUtils.java
@@ -103,14 +103,29 @@ public final class ImageUtils {
      * @return updated image based on the parameters
      */
     public static String changeRegistryOrgAndTag(String image, String newRegistry, String newOrg, String newTag) {
+        return changeRegistryOrgImageAndTag(image, newRegistry, newOrg, null, newTag);
+    }
+
+    /**
+     * Method that, for specified {@param image}, replaces the registry, organization, imageName and tag, based on the parameters.
+     *
+     * @param image the image
+     * @param newRegistry the new registry
+     * @param newOrg the new org
+     * @param newImageName the new image name
+     * @param newTag the new tag
+     * @return the string
+     */
+    public static String changeRegistryOrgImageAndTag(String image, String newRegistry, String newOrg, String newImageName, String newTag) {
         Matcher m = IMAGE_PATTERN_FULL_PATH.matcher(image);
 
         if (m.find()) {
             String registry = setImagePropertiesIfNeeded(m.group("registry"), newRegistry);
             String org = setImagePropertiesIfNeeded(m.group("org"), newOrg);
             String tag = setImagePropertiesIfNeeded(m.group("tag"), newTag);
+            String imageName = setImagePropertiesIfNeeded(m.group("image"), newImageName);
 
-            String newImage = registry + "/" + org + "/" + m.group("image") + ":" + tag;
+            String newImage = registry + "/" + org + "/" + imageName + ":" + tag;
 
             LOGGER.info("Updating container image to {}", newImage);
 
@@ -123,8 +138,9 @@ public final class ImageUtils {
             String registry = newRegistry != null ? newRegistry + "/" : "";
             String org = setImagePropertiesIfNeeded(m.group("org"), newOrg);
             String tag = setImagePropertiesIfNeeded(m.group("tag"), newTag);
+            String imageName = setImagePropertiesIfNeeded(m.group("image"), newImageName);
 
-            String newImage = registry + org + "/" + m.group("image") + ":" + tag;
+            String newImage = registry + org + "/" + imageName + ":" + tag;
 
             LOGGER.info("Updating container image to {}", newImage);
 


### PR DESCRIPTION
## Description

While developing the new system tests for the Kroxylicious operator, I realized that if I wanted to change also the name if the image of the repository, it was not possible because the current method didn't change that.

This would be very useful for our tests because we need to change the name of the image for PR tests.


## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit/integration tests pass locally with my changes
