### PR TITLE
Add replaceContent method to CmdKubeClient

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClient.java
@@ -263,6 +263,22 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     }
 
     /**
+     * Replaces YAML content.
+     *
+     * @param yamlContent The YAML content.
+     * @return The instance of the client.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public K replaceContent(String yamlContent) {
+        try (Context context = defaultContext()) {
+            Exec.exec(yamlContent, command(Arrays.asList(REPLACE, "-f", "-")), 0,
+                true, true);
+            return (K) this;
+        }
+    }
+
+    /**
      * Deletes YAML content.
      *
      * @param yamlContent The YAML content.

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
@@ -121,6 +121,13 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     K applyContent(String yamlContent);
 
     /**
+     * Replaces resource content
+     * @param yamlContent The YAML content representing the resources.
+     * @return This kube client.
+     */
+    K replaceContent(String yamlContent);
+
+    /**
      * Deletes resource content.
      *
      * @param yamlContent The YAML content representing the resources to delete.


### PR DESCRIPTION
## Description

This small PR adds `replaceContent` to the CmdKubeClient, so we have all needed methods for creation of the content, deletion and also for replacing it in case of need.

## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit/integration tests pass locally with my changes
