### PR TITLE
Move UtilsTest to use mocked methods instead Kube mock server

### DIFF
--- a/test-frame-common/pom.xml
+++ b/test-frame-common/pom.xml
@@ -87,6 +87,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/UtilsTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/UtilsTest.java
@@ -5,9 +5,22 @@
 package io.skodjob.testframe.clients;
 
 import io.fabric8.kubernetes.api.builder.Visitor;
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.NamespaceList;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodConditionBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.*;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.skodjob.testframe.annotations.ResourceManager;
 import io.skodjob.testframe.annotations.TestVisualSeparator;
 import io.skodjob.testframe.resources.KubeResourceManager;
@@ -23,7 +36,9 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 @ResourceManager
 @TestVisualSeparator
@@ -86,7 +101,8 @@ class UtilsTest {
         try (MockedStatic<KubeResourceManager> mockedStatic = mockStatic(KubeResourceManager.class)) {
             when(KubeResourceManager.get()).thenReturn(kubeResourceManager);
 
-            NonNamespaceOperation<Namespace, NamespaceList, Resource<Namespace>> namespaceOperation = mock(NonNamespaceOperation.class);
+            NonNamespaceOperation<Namespace, NamespaceList,
+                Resource<Namespace>> namespaceOperation = mock(NonNamespaceOperation.class);
             Resource<Namespace> namespaceResource = mock(Resource.class);
 
             Namespace labeledNamespace = new NamespaceBuilder()


### PR DESCRIPTION
## Description

This PR moves `UtilsTest` to use mocked methods instead of Kube mocked server, which caused issues in CI when running different tests.

## Type of Change

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
