### PR TITLE
Add possibility to specify log level in exec commands

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/enums/LogLevel.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/enums/LogLevel.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Skodjob authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.skodjob.testframe.enums;
+
+import org.slf4j.event.Level;
+
+/**
+ * Enum class capturing available log levels that can be used in Test-Frame.
+ */
+public enum LogLevel {
+    /**
+     * Debug log level
+     */
+    DEBUG,
+    /**
+     * Info log level
+     */
+    INFO,
+    /**
+     * Warn log level
+     */
+    WARN,
+    /**
+     * Error log level
+     */
+    ERROR,
+    /**
+     * Trace log level
+     */
+    TRACE;
+
+    /**
+     * Based on {@param level} returns corresponding slf4j's log level (as {@link Level}.
+     *
+     * @param level     Desired log level.
+     *
+     * @return  based on {@param level} returns corresponding slf4j's log level (as {@link Level}.
+     */
+    public static Level logLevelToLevel(LogLevel level) {
+        switch (level) {
+            case INFO: return Level.INFO;
+            case WARN: return Level.WARN;
+            case ERROR: return Level.ERROR;
+            case TRACE: return Level.TRACE;
+            default: return Level.DEBUG;
+        }
+    }
+}


### PR DESCRIPTION
## Description

In one of the previous PRs the option to enable/disable logging to output when the `exec` command is executed.
But in some cases - like commands generating long output - we want to log it, but on different level - for example just for debug in case that there is some failure, so we have more logs to check.

This PR adds possibility to specify log level in the `exec` commands.
For better usage (without need of adding the `slf4j` library directly into the code) I created the `LogLevel` enum, which contains all possible log levels and then it returns the appropriate `Level` enum from sl4j, so it can be used in the `LOGGER.atLevel()` method.

## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit/integration tests pass locally with my changes
