### PR TITLE
Add option to specify LogLevel into KubeCmdClient

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClient.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import io.skodjob.testframe.clients.KubeClusterException;
+import io.skodjob.testframe.enums.LogLevel;
 import io.skodjob.testframe.executor.Exec;
 import io.skodjob.testframe.executor.ExecResult;
 import org.slf4j.Logger;
@@ -354,6 +355,23 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     }
 
     /**
+     * Executes a command within a pod.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param logLevel  Desired log level where the log
+     *                  from the command execution should be printed.
+     * @param pod       The name of the pod.
+     * @param command   The command to execute.
+     *
+     * @return The execution result.
+     */
+    @Override
+    public ExecResult execInPod(LogLevel logLevel, String pod, String... command) {
+        return execInPod(true, logLevel, pod, command);
+    }
+
+    /**
      * Executes a command in a pod.
      *
      * @param throwError     Whether to throw errors.
@@ -363,9 +381,26 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
      */
     @Override
     public ExecResult execInPod(boolean throwError, String pod, String... command) {
+        return execInPod(throwError, LogLevel.INFO, pod, command);
+    }
+
+    /**
+     * Executes a command within a pod.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param throwError     Whether to throw errors.
+     * @param logLevel       Desired log level where the log
+     *                       from the command execution should be printed.
+     * @param pod            The name of the pod.
+     * @param command        The command to execute.
+     * @return The execution result.
+     */
+    @Override
+    public ExecResult execInPod(boolean throwError, LogLevel logLevel, String pod, String... command) {
         List<String> cmd = command("exec", pod, "--");
         cmd.addAll(asList(command));
-        return Exec.exec(null, cmd, 0, false, throwError);
+        return Exec.exec(null, cmd, 0, logLevel, false, throwError);
     }
 
     /**
@@ -379,6 +414,23 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @Override
     public ExecResult execInPodContainer(String pod, String container, String... command) {
         return execInPodContainer(true, pod, container, command);
+    }
+
+    /**
+     * Executes a command within a pod container.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param logLevel       Desired log level where the log
+     *                       from the command execution should be printed.
+     * @param pod            The name of the pod.
+     * @param container      The name of the container.
+     * @param command        The command to execute.
+     * @return The execution result.
+     */
+    @Override
+    public ExecResult execInPodContainer(LogLevel logLevel, String pod, String container, String... command) {
+        return execInPodContainer(logLevel, true, pod, container, command);
     }
 
     /**
@@ -397,6 +449,26 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
 
     /**
      * Executes a command within a pod container with logging to output control.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param logLevel       Desired log level where the log
+     *                       from the command execution should be printed.
+     * @param logToOutput    Determines if the output should be logged.
+     * @param pod            The name of the pod.
+     * @param container      The name of the container.
+     * @param command        The command to execute.
+     *
+     * @return The execution result.
+     */
+    @Override
+    public ExecResult execInPodContainer(LogLevel logLevel, boolean logToOutput,
+                                         String pod, String container, String... command) {
+        return execInPodContainer(true, logLevel, logToOutput, pod, container, command);
+    }
+
+    /**
+     * Executes a command within a pod container with logging to output control.
      *
      * @param throwError     Whether to throw errors.
      * @param logToOutput    Determines if the output should be logged.
@@ -408,9 +480,29 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @Override
     public ExecResult execInPodContainer(boolean throwError, boolean logToOutput,
                                          String pod, String container, String... command) {
+        return execInPodContainer(throwError, LogLevel.INFO, logToOutput, pod, container, command);
+    }
+
+    /**
+     * Executes a command within a pod container with logging to output control.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param throwError     Whether to throw errors.
+     * @param logLevel       Desired log level where the log
+     *                       from the command execution should be printed.
+     * @param logToOutput    Determines if the output should be logged.
+     * @param pod            The name of the pod.
+     * @param container      The name of the container.
+     * @param command        The command to execute.
+     * @return The execution result.
+     */
+    @Override
+    public ExecResult execInPodContainer(boolean throwError, LogLevel logLevel, boolean logToOutput,
+                                         String pod, String container, String... command) {
         List<String> cmd = command("exec", pod, "-c", container, "--");
         cmd.addAll(asList(command));
-        return Exec.exec(null, cmd, 0, logToOutput, throwError);
+        return Exec.exec(null, cmd, 0, logLevel, logToOutput, throwError);
     }
 
     /**
@@ -425,6 +517,22 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     }
 
     /**
+     * Executes a command - printing output to desired log level.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param command  The command to execute.
+     * @param logLevel Desired log level where the log
+     *                 from the command execution should be printed.
+     *
+     * @return The execution result.
+     */
+    @Override
+    public ExecResult exec(LogLevel logLevel, String... command) {
+        return exec(true, logLevel, command);
+    }
+
+    /**
      * Executes a command with the option to throw errors.
      *
      * @param throwError Whether to throw errors.
@@ -434,6 +542,22 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @Override
     public ExecResult exec(boolean throwError, String... command) {
         return exec(throwError, true, command);
+    }
+
+    /**
+     * Executes a command with control over throwing exceptions on failure.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param throwError    Determines if an exception should be thrown on failure.
+     * @param logLevel      Desired log level where the log
+     *                      from the command execution should be printed.
+     * @param command       The command to execute.
+     * @return The execution result.
+     */
+    @Override
+    public ExecResult exec(boolean throwError, LogLevel logLevel, String... command) {
+        return exec(throwError, logLevel, true, command);
     }
 
     /**
@@ -451,6 +575,23 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     }
 
     /**
+     * Executes a command with control over throwing exceptions on failure and logging to output control.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param throwError    Determines if an exception should be thrown on failure.
+     * @param logLevel      Desired log level where the log
+     *                      from the command execution should be printed.
+     * @param logToOutput   Determines if the output should be logged.
+     * @param command       The command to execute.
+     * @return The execution result.
+     */
+    @Override
+    public ExecResult exec(boolean throwError, LogLevel logLevel, boolean logToOutput, String... command) {
+        return exec(throwError, logLevel, logToOutput, 0, command);
+    }
+
+    /**
      * Executes a command with the option to throw errors and log to output.
      *
      * @param throwError  Whether to throw errors.
@@ -461,8 +602,22 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
      */
     @Override
     public ExecResult exec(boolean throwError, boolean logToOutput, int timeout, String... command) {
+        return exec(throwError, LogLevel.INFO, logToOutput, timeout, command);
+    }
+
+    /**
+     * Execute the given {@code command}. You can specify if potential failure will throw the exception or not.
+     *
+     * @param throwError  parameter which control thrown exception in case of failure
+     * @param command     The command
+     * @param timeout     tiemout in ms
+     * @param logToOutput determines if we want to print whole output of command
+     * @return The process result.
+     */
+    @Override
+    public ExecResult exec(boolean throwError, LogLevel logLevel, boolean logToOutput, int timeout, String... command) {
         List<String> cmd = command(asList(command));
-        return Exec.exec(null, cmd, timeout, logToOutput, throwError);
+        return Exec.exec(null, cmd, timeout, logLevel, logToOutput, throwError);
     }
 
     /**

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import io.skodjob.testframe.enums.LogLevel;
 import io.skodjob.testframe.executor.ExecResult;
 
 /**
@@ -172,6 +173,20 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
 
     /**
      * Executes a command within a pod.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param logLevel  Desired log level where the log
+     *                  from the command execution should be printed.
+     * @param pod       The name of the pod.
+     * @param command   The command to execute.
+     *
+     * @return The execution result.
+     */
+    ExecResult execInPod(LogLevel logLevel, String pod, String... command);
+
+    /**
+     * Executes a command within a pod.
      *
      * @param throwError     Whether to throw errors.
      * @param pod            The name of the pod.
@@ -179,6 +194,20 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      * @return The execution result.
      */
     ExecResult execInPod(boolean throwError, String pod, String... command);
+
+    /**
+     * Executes a command within a pod.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param throwError     Whether to throw errors.
+     * @param logLevel       Desired log level where the log
+     *                       from the command execution should be printed.
+     * @param pod            The name of the pod.
+     * @param command        The command to execute.
+     * @return The execution result.
+     */
+    ExecResult execInPod(boolean throwError, LogLevel logLevel, String pod, String... command);
 
     /**
      * Executes a command within a pod container.
@@ -189,6 +218,20 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      * @return The execution result.
      */
     ExecResult execInPodContainer(String pod, String container, String... command);
+
+    /**
+     * Executes a command within a pod container.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param logLevel       Desired log level where the log
+     *                       from the command execution should be printed.
+     * @param pod            The name of the pod.
+     * @param container      The name of the container.
+     * @param command        The command to execute.
+     * @return The execution result.
+     */
+    ExecResult execInPodContainer(LogLevel logLevel, String pod, String container, String... command);
 
     /**
      * Executes a command within a pod container with logging to output control.
@@ -203,6 +246,23 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
 
     /**
      * Executes a command within a pod container with logging to output control.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param logLevel       Desired log level where the log
+     *                       from the command execution should be printed.
+     * @param logToOutput    Determines if the output should be logged.
+     * @param pod            The name of the pod.
+     * @param container      The name of the container.
+     * @param command        The command to execute.
+     *
+     * @return The execution result.
+     */
+    ExecResult execInPodContainer(LogLevel logLevel, boolean logToOutput,
+                                  String pod, String container, String... command);
+
+    /**
+     * Executes a command within a pod container with logging to output control.
      *
      * @param throwError     Whether to throw errors.
      * @param logToOutput    Determines if the output should be logged.
@@ -212,6 +272,22 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      * @return The execution result.
      */
     ExecResult execInPodContainer(boolean throwError, boolean logToOutput,
+                                  String pod, String container, String... command);
+    /**
+     * Executes a command within a pod container with logging to output control.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param throwError     Whether to throw errors.
+     * @param logLevel       Desired log level where the log
+     *                       from the command execution should be printed.
+     * @param logToOutput    Determines if the output should be logged.
+     * @param pod            The name of the pod.
+     * @param container      The name of the container.
+     * @param command        The command to execute.
+     * @return The execution result.
+     */
+    ExecResult execInPodContainer(boolean throwError, LogLevel logLevel, boolean logToOutput,
                                   String pod, String container, String... command);
 
     /**
@@ -223,6 +299,19 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     ExecResult exec(String... command);
 
     /**
+     * Executes a command - printing output to desired log level.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param command  The command to execute.
+     * @param logLevel Desired log level where the log
+     *                 from the command execution should be printed.
+     *
+     * @return The execution result.
+     */
+    ExecResult exec(LogLevel logLevel, String... command);
+
+    /**
      * Executes a command with control over throwing exceptions on failure.
      *
      * @param throwError Determines if an exception should be thrown on failure.
@@ -230,6 +319,19 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      * @return The execution result.
      */
     ExecResult exec(boolean throwError, String... command);
+
+    /**
+     * Executes a command with control over throwing exceptions on failure.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param throwError    Determines if an exception should be thrown on failure.
+     * @param logLevel      Desired log level where the log
+     *                      from the command execution should be printed.
+     * @param command       The command to execute.
+     * @return The execution result.
+     */
+    ExecResult exec(boolean throwError, LogLevel logLevel, String... command);
 
     /**
      * Executes a command with control over throwing exceptions on failure and logging to output control.
@@ -242,15 +344,45 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
     ExecResult exec(boolean throwError, boolean logToOutput, String... command);
 
     /**
+     * Executes a command with control over throwing exceptions on failure and logging to output control.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param throwError    Determines if an exception should be thrown on failure.
+     * @param logLevel      Desired log level where the log
+     *                      from the command execution should be printed.
+     * @param logToOutput   Determines if the output should be logged.
+     * @param command       The command to execute.
+     * @return The execution result.
+     */
+    ExecResult exec(boolean throwError, LogLevel logLevel, boolean logToOutput, String... command);
+
+    /**
      * Execute the given {@code command}. You can specify if potential failure will throw the exception or not.
      *
-     * @param throwError  parameter which control thrown exception in case of failure
+     * @param throwError  Parameter which control thrown exception in case of failure
      * @param command     The command
-     * @param timeout     tiemout in ms
-     * @param logToOutput determines if we want to print whole output of command
+     * @param timeout     Timeout in ms
+     * @param logToOutput Determines if we want to print whole output of command
+     *
      * @return The process result.
      */
     ExecResult exec(boolean throwError, boolean logToOutput, int timeout, String... command);
+
+    /**
+     * Execute the given {@code command}. You can specify if potential failure will throw the exception or not.
+     * Specifying {@param logLevel} you can configure a log level where
+     * all the logs from the command execution will be printed into.
+     *
+     * @param throwError    Parameter which control thrown exception in case of failure
+     * @param logLevel      Desired log level where the log
+     *                      from the command execution should be printed.
+     * @param command       The command
+     * @param timeout       Timeout in ms
+     * @param logToOutput   Determines if we want to print whole output of command
+     * @return The process result.
+     */
+    ExecResult exec(boolean throwError, LogLevel logLevel, boolean logToOutput, int timeout, String... command);
 
     /**
      * Retrieves the YAML content of a resource.

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClientTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClientTest.java
@@ -35,7 +35,11 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -409,13 +413,15 @@ class BaseCmdKubeClientTest {
         String podName = "my-pod-123";
         String[] cmdToRun = {"ls", "-l"};
         ExecResult mockResult = mockSuccessfulExecResult("total 0");
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO), eq(false), eq(true))).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO),
+            eq(false), eq(true))).thenReturn(mockResult);
 
         ExecResult actualResult = client.execInPod(podName, cmdToRun);
 
         assertSame(mockResult, actualResult);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0), eq(LogLevel.INFO), eq(false), eq(true)));
+        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0),
+            eq(LogLevel.INFO), eq(false), eq(true)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedParts = Arrays.asList("exec", podName, "--", "ls", "-l");
         assertTrue(capturedCommand.containsAll(expectedParts));
@@ -428,14 +434,16 @@ class BaseCmdKubeClientTest {
         String containerName = "my-container";
         String[] cmdToRun = {"ps", "aux"};
         ExecResult mockResult = mockSuccessfulExecResult("USER PID ...");
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO), eq(true), eq(true))).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO),
+            eq(true), eq(true))).thenReturn(mockResult);
 
 
         ExecResult actualResult = client.execInPodContainer(podName, containerName, cmdToRun);
         assertSame(mockResult, actualResult);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0), eq(LogLevel.INFO), eq(true), eq(true)));
+        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0),
+            eq(LogLevel.INFO), eq(true), eq(true)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedParts = Arrays.asList("exec", podName, "-c", containerName, "--", "ps", "aux");
         assertTrue(capturedCommand.containsAll(expectedParts));
@@ -449,13 +457,15 @@ class BaseCmdKubeClientTest {
         String[] cmdToRun = {"env"};
         boolean logToOutput = false;
         ExecResult mockResult = mockSuccessfulExecResult("PATH=/usr/bin");
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO), eq(logToOutput), eq(true))).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO),
+            eq(logToOutput), eq(true))).thenReturn(mockResult);
 
         ExecResult actualResult = client.execInPodContainer(logToOutput, podName, containerName, cmdToRun);
 
         assertSame(mockResult, actualResult);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0), eq(LogLevel.INFO), eq(logToOutput), eq(true)));
+        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0),
+            eq(LogLevel.INFO), eq(logToOutput), eq(true)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedParts = Arrays.asList("exec", podName, "-c", containerName, "--", "env");
         assertTrue(capturedCommand.containsAll(expectedParts));
@@ -523,7 +533,8 @@ class BaseCmdKubeClientTest {
         int timeout = 5000;
         String[] cmdToRun = {"api-resources"};
         ExecResult mockResult = mockSuccessfulExecResult("NAME SHORTNAMES ...");
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(timeout), eq(LogLevel.INFO), eq(logToOutput), eq(throwError)))
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(timeout),
+                eq(LogLevel.INFO), eq(logToOutput), eq(throwError)))
             .thenReturn(mockResult);
 
         ExecResult actualResult = client.exec(throwError, logToOutput, timeout, cmdToRun);

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClientTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClientTest.java
@@ -5,6 +5,7 @@
 package io.skodjob.testframe.clients.cmdClient;
 
 import io.skodjob.testframe.clients.KubeClusterException;
+import io.skodjob.testframe.enums.LogLevel;
 import io.skodjob.testframe.executor.Exec;
 import io.skodjob.testframe.executor.ExecResult;
 import org.junit.jupiter.api.AfterEach;
@@ -34,11 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -412,13 +409,13 @@ class BaseCmdKubeClientTest {
         String podName = "my-pod-123";
         String[] cmdToRun = {"ls", "-l"};
         ExecResult mockResult = mockSuccessfulExecResult("total 0");
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(false), eq(true))).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO), eq(false), eq(true))).thenReturn(mockResult);
 
         ExecResult actualResult = client.execInPod(podName, cmdToRun);
 
         assertSame(mockResult, actualResult);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0), eq(false), eq(true)));
+        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0), eq(LogLevel.INFO), eq(false), eq(true)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedParts = Arrays.asList("exec", podName, "--", "ls", "-l");
         assertTrue(capturedCommand.containsAll(expectedParts));
@@ -431,14 +428,14 @@ class BaseCmdKubeClientTest {
         String containerName = "my-container";
         String[] cmdToRun = {"ps", "aux"};
         ExecResult mockResult = mockSuccessfulExecResult("USER PID ...");
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(true), eq(true))).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO), eq(true), eq(true))).thenReturn(mockResult);
 
 
         ExecResult actualResult = client.execInPodContainer(podName, containerName, cmdToRun);
         assertSame(mockResult, actualResult);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0), eq(true), eq(true)));
+        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0), eq(LogLevel.INFO), eq(true), eq(true)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedParts = Arrays.asList("exec", podName, "-c", containerName, "--", "ps", "aux");
         assertTrue(capturedCommand.containsAll(expectedParts));
@@ -452,13 +449,13 @@ class BaseCmdKubeClientTest {
         String[] cmdToRun = {"env"};
         boolean logToOutput = false;
         ExecResult mockResult = mockSuccessfulExecResult("PATH=/usr/bin");
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(logToOutput), eq(true))).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO), eq(logToOutput), eq(true))).thenReturn(mockResult);
 
         ExecResult actualResult = client.execInPodContainer(logToOutput, podName, containerName, cmdToRun);
 
         assertSame(mockResult, actualResult);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0), eq(logToOutput), eq(true)));
+        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(0), eq(LogLevel.INFO), eq(logToOutput), eq(true)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedParts = Arrays.asList("exec", podName, "-c", containerName, "--", "env");
         assertTrue(capturedCommand.containsAll(expectedParts));
@@ -526,7 +523,7 @@ class BaseCmdKubeClientTest {
         int timeout = 5000;
         String[] cmdToRun = {"api-resources"};
         ExecResult mockResult = mockSuccessfulExecResult("NAME SHORTNAMES ...");
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(timeout), eq(logToOutput), eq(throwError)))
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(timeout), eq(LogLevel.INFO), eq(logToOutput), eq(throwError)))
             .thenReturn(mockResult);
 
         ExecResult actualResult = client.exec(throwError, logToOutput, timeout, cmdToRun);
@@ -534,7 +531,7 @@ class BaseCmdKubeClientTest {
         assertSame(mockResult, actualResult);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
         mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture(), eq(timeout),
-            eq(logToOutput), eq(throwError)));
+            eq(LogLevel.INFO), eq(logToOutput), eq(throwError)));
         List<String> capturedCommand = listCaptor.getValue();
         assertTrue(capturedCommand.contains("api-resources"));
     }
@@ -867,9 +864,9 @@ class BaseCmdKubeClientTest {
         String podName = "my-pod";
 
         ExecResult mockResult = mockFailedExecResult("Error: permission denied", 1);
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(false), eq(false)))
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO), eq(false), eq(false)))
             .thenReturn(mockResult);
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(false), eq(true)))
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO), eq(false), eq(true)))
             .thenThrow(new KubeClusterException(new Exception("Failed to execute command")));
 
         assertDoesNotThrow(() -> client.execInPod(false, podName, command));
@@ -883,9 +880,9 @@ class BaseCmdKubeClientTest {
         String containerName = "container";
 
         ExecResult mockResult = mockFailedExecResult("Error: permission denied", 1);
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(false), eq(false)))
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO), eq(false), eq(false)))
             .thenReturn(mockResult);
-        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(false), eq(true)))
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(LogLevel.INFO), eq(false), eq(true)))
             .thenThrow(new KubeClusterException(new Exception("Failed to execute command")));
 
         assertDoesNotThrow(() -> client.execInPodContainer(false, false, podName, containerName, command));

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClientTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClientTest.java
@@ -900,4 +900,100 @@ class BaseCmdKubeClientTest {
         assertThrows(KubeClusterException.class,
             () -> client.execInPodContainer(true, false, podName, containerName, command));
     }
+
+    @Test
+    void testExecWithLogLevel() {
+        String command = "ls";
+        LogLevel logLevel = LogLevel.ERROR;
+
+        ExecResult mockResult = mockSuccessfulExecResult("This is my files");
+
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0),
+            eq(logLevel), eq(true), eq(true))).thenReturn(mockResult);
+
+        ExecResult actualResult = client.exec(logLevel, command);
+
+        assertSame(mockResult, actualResult);
+        ArgumentCaptor<LogLevel> logLevelCaptor = ArgumentCaptor.forClass(LogLevel.class);
+        mockedExec.verify(() -> Exec.exec(isNull(), anyList(), eq(0),
+            logLevelCaptor.capture(), eq(true), eq(true)));
+        LogLevel capturedLogLevel = logLevelCaptor.getValue();
+        assertTrue(capturedLogLevel.equals(LogLevel.ERROR));
+    }
+
+    @Test
+    void testExecWithLogLevelAndThrowErrors() {
+        String command = "ls";
+        LogLevel logLevel = LogLevel.ERROR;
+        boolean throwErrors = true;
+
+        ExecResult mockResult = mockSuccessfulExecResult("This is my files");
+
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0),
+            eq(logLevel), eq(true), eq(throwErrors))).thenReturn(mockResult);
+
+        ExecResult actualResult = client.exec(throwErrors, logLevel, command);
+        assertSame(mockResult, actualResult);
+
+        ArgumentCaptor<LogLevel> logLevelCaptor = ArgumentCaptor.forClass(LogLevel.class);
+        ArgumentCaptor<Boolean> throwErrorCaptor = ArgumentCaptor.forClass(Boolean.class);
+
+        mockedExec.verify(() -> Exec.exec(isNull(), anyList(), eq(0),
+            logLevelCaptor.capture(), eq(true), throwErrorCaptor.capture()));
+        LogLevel capturedLogLevel = logLevelCaptor.getValue();
+        Boolean capturedThrowErrors = throwErrorCaptor.getValue();
+
+        assertTrue(capturedLogLevel.equals(LogLevel.ERROR));
+        assertTrue(capturedThrowErrors.equals(throwErrors));
+    }
+
+    @Test
+    void testExecWithLogLevels() {
+        String command = "ls";
+        LogLevel logLevel = LogLevel.ERROR;
+        boolean throwErrors = true;
+
+        ExecResult mockResult = mockSuccessfulExecResult("This is my files");
+
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0),
+            eq(logLevel), eq(true), eq(throwErrors))).thenReturn(mockResult);
+
+        ExecResult actualResult = client.exec(throwErrors, logLevel, command);
+        assertSame(mockResult, actualResult);
+
+        ArgumentCaptor<LogLevel> logLevelCaptor = ArgumentCaptor.forClass(LogLevel.class);
+        ArgumentCaptor<Boolean> throwErrorCaptor = ArgumentCaptor.forClass(Boolean.class);
+
+        mockedExec.verify(() -> Exec.exec(isNull(), anyList(), eq(0),
+            logLevelCaptor.capture(), eq(true), throwErrorCaptor.capture()));
+        LogLevel capturedLogLevel = logLevelCaptor.getValue();
+        Boolean capturedThrowErrors = throwErrorCaptor.getValue();
+
+        assertTrue(capturedLogLevel.equals(LogLevel.ERROR));
+        assertTrue(capturedThrowErrors.equals(throwErrors));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testExecInPodContainerWithLogLevel() {
+        String podName = "my-pod-789";
+        String containerName = "another-container";
+        String[] cmdToRun = {"env"};
+        LogLevel logLevel = LogLevel.ERROR;
+
+        ExecResult mockResult = mockSuccessfulExecResult("PATH=/usr/bin");
+        mockedExec.when(() -> Exec.exec(isNull(), anyList(), eq(0), eq(logLevel),
+            eq(true), eq(true))).thenReturn(mockResult);
+
+        ExecResult actualResult = client.execInPodContainer(logLevel, true, podName, containerName, cmdToRun);
+        assertSame(mockResult, actualResult);
+
+        ArgumentCaptor<LogLevel> logLevelCaptor = ArgumentCaptor.forClass(LogLevel.class);
+
+        mockedExec.verify(() -> Exec.exec(isNull(), anyList(), eq(0),
+            logLevelCaptor.capture(), eq(true), eq(true)));
+        LogLevel capturedLogLevel = logLevelCaptor.getValue();
+
+        assertTrue(capturedLogLevel.equals(LogLevel.ERROR));
+    }
 }


### PR DESCRIPTION
## Description

In previous PR (#295) I added possibility to specify log level into the `Exec` class and the `exec` method.
But it would be useful to have the same thing also in the KubeCmdClient.

This PR adds this possibility to the KubeCmdClient class as well.

## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit/integration tests pass locally with my changes
