### PR TITLE
Add ability to run kubeCmdClient with timeout

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
@@ -44,6 +44,15 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
      */
     KubeCmdClient<K> inNamespace(String namespace);
 
+
+    /**
+     * Sets the timeout for subsequent operations.
+     *
+     * @param timeout timeout for execution of command.
+     * @return This kube client.
+     */
+    KubeCmdClient<K> withTimeout(int timeout);
+
     /**
      * Retrieves the currently set namespace for the Kubernetes client.
      *

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Kubectl.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Kubectl.java
@@ -29,11 +29,11 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
      * @param config The configuration to use.
      */
     public Kubectl(String config) {
-        super(config);
+        super(config, 0);
     }
 
-    private Kubectl(String futureNamespace, String config) {
-        super(config);
+    private Kubectl(String futureNamespace, String config, int timeout) {
+        super(config, timeout);
         namespace = futureNamespace;
     }
 
@@ -45,7 +45,18 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
      */
     @Override
     public Kubectl inNamespace(String namespace) {
-        return new Kubectl(namespace, config);
+        return new Kubectl(namespace, config, timeout);
+    }
+
+    /**
+     * Sets the timeout for subsequent operations.
+     *
+     * @param timeout timeout for execution of command.
+     * @return This kube client.
+     */
+    @Override
+    public Kubectl withTimeout(int timeout) {
+        return new Kubectl(namespace, config, timeout);
     }
 
     /**
@@ -85,7 +96,8 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
      */
     @Override
     public String getUsername() {
-        return Exec.exec(command("auth", "whoami", "-o", "jsonpath='{.status.userInfo.username}'")).out();
+        return Exec.exec(command("auth", "whoami", "-o", "jsonpath='{.status.userInfo.username}'"), timeout)
+            .out();
     }
 
     /**
@@ -95,7 +107,7 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
      */
     @Override
     public void cordon(String nodeName) {
-        Exec.exec(command("cordon", nodeName));
+        Exec.exec(command("cordon", nodeName), timeout);
     }
 
     /**
@@ -105,7 +117,7 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
      */
     @Override
     public void uncordon(String nodeName) {
-        Exec.exec(command("uncordon", nodeName));
+        Exec.exec(command("uncordon", nodeName), timeout);
     }
 
     /**
@@ -122,6 +134,6 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
         Exec.exec(command("drain", nodeName,
             "--ignore-daemonsets", String.valueOf(ignoreDaemonSets),
             "--disable-eviction", String.valueOf(disableEviction),
-            "--timeout", timeoutInSeconds + "s"));
+            "--timeout", timeoutInSeconds + "s"), timeout);
     }
 }

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Oc.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Oc.java
@@ -32,11 +32,11 @@ public class Oc extends BaseCmdKubeClient<Oc> {
      * @param config The configuration to use.
      */
     public Oc(String config) {
-        super(config);
+        super(config, 0);
     }
 
-    private Oc(String futureNamespace, String config) {
-        super(config);
+    private Oc(String futureNamespace, String config, int timeout) {
+        super(config, timeout);
         namespace = futureNamespace;
     }
 
@@ -58,7 +58,18 @@ public class Oc extends BaseCmdKubeClient<Oc> {
      */
     @Override
     public Oc inNamespace(String namespace) {
-        return new Oc(namespace, config);
+        return new Oc(namespace, config, timeout);
+    }
+
+    /**
+     * Sets the timeout for subsequent operations.
+     *
+     * @param timeout timeout for execution of command.
+     * @return This kube client.
+     */
+    @Override
+    public Oc withTimeout(int timeout) {
+        return new Oc(namespace, config, timeout);
     }
 
     /**
@@ -80,7 +91,7 @@ public class Oc extends BaseCmdKubeClient<Oc> {
     @Override
     public Oc createNamespace(String name) {
         try (Context context = defaultContext()) {
-            Exec.exec(cmd(), "new-project", name);
+            Exec.exec(timeout, cmd(), "new-project", name);
         }
         return this;
     }
@@ -99,7 +110,7 @@ public class Oc extends BaseCmdKubeClient<Oc> {
             cmd.add(entry.getKey() + "=" + entry.getValue());
         }
 
-        Exec.exec(cmd);
+        Exec.exec(cmd, timeout);
         return this;
     }
 
@@ -120,7 +131,7 @@ public class Oc extends BaseCmdKubeClient<Oc> {
      */
     @Override
     public String getUsername() {
-        return Exec.exec(command("whoami")).out();
+        return Exec.exec(command("whoami"), timeout).out();
     }
 
     /**
@@ -130,7 +141,7 @@ public class Oc extends BaseCmdKubeClient<Oc> {
      */
     @Override
     public void cordon(String nodeName) {
-        Exec.exec(command("adm", "cordon", nodeName));
+        Exec.exec(command("adm", "cordon", nodeName), timeout);
     }
 
     /**
@@ -140,7 +151,7 @@ public class Oc extends BaseCmdKubeClient<Oc> {
      */
     @Override
     public void uncordon(String nodeName) {
-        Exec.exec(command("adm", "uncordon", nodeName));
+        Exec.exec(command("adm", "uncordon", nodeName), timeout);
     }
 
     /**
@@ -157,6 +168,6 @@ public class Oc extends BaseCmdKubeClient<Oc> {
         Exec.exec(command("adm", "drain", nodeName,
             "--ignore-daemonsets", String.valueOf(ignoreDaemonSets),
             "--disable-eviction", String.valueOf(disableEviction),
-            "--timeout", timeoutInSeconds + "s"));
+            "--timeout", timeoutInSeconds + "s"), timeout);
     }
 }

--- a/test-frame-common/src/main/java/io/skodjob/testframe/executor/Exec.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/executor/Exec.java
@@ -125,6 +125,17 @@ public class Exec {
     /**
      * Method executes external command
      *
+     * @param timeout timeout for command
+     * @param command arguments for command
+     * @return execution results
+     */
+    public static ExecResult exec(int timeout, String... command) {
+        return exec(Arrays.asList(command), timeout);
+    }
+
+    /**
+     * Method executes external command
+     *
      * @param command     arguments for command
      * @param logToOutput log output or not
      * @return execution results
@@ -154,6 +165,17 @@ public class Exec {
      */
     public static ExecResult exec(List<String> command) {
         return exec(null, command, 0, false);
+    }
+
+    /**
+     * Method executes external command
+     *
+     * @param command arguments for command
+     * @param timeout timeout for command executed
+     * @return execution results
+     */
+    public static ExecResult exec(List<String> command, int timeout) {
+        return exec(null, command, timeout, false);
     }
 
     /**

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClientTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/BaseCmdKubeClientTest.java
@@ -122,12 +122,12 @@ class BaseCmdKubeClientTest {
         String resourceName = "my-pod";
         ExecResult mockResult = mockSuccessfulExecResult(null);
 
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         client.deleteByName(resourceType, resourceName);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedCommand = Arrays.asList(TEST_CMD, "--kubeconfig", TEST_CONFIG,
             "--namespace", TEST_NAMESPACE, "delete", resourceType, resourceName);
         assertEquals(expectedCommand, listCaptor.getValue());
@@ -142,7 +142,7 @@ class BaseCmdKubeClientTest {
         ExecResult mockResult = mockSuccessfulExecResult(expectedYaml);
 
         ArgumentCaptor<List<String>> commandCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.when(() -> Exec.exec(commandCaptor.capture())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(commandCaptor.capture(), eq(0))).thenReturn(mockResult);
 
         String actualYaml = client.get(resourceType, resourceName);
 
@@ -157,13 +157,13 @@ class BaseCmdKubeClientTest {
     void testGetEvents() {
         String expectedEvents = "LAST SEEN   TYPE      REASON      OBJECT      MESSAGE";
         ExecResult mockResult = mockSuccessfulExecResult(expectedEvents);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         String actualEvents = client.getEvents();
         assertEquals(expectedEvents, actualEvents);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedCommand = Arrays.asList(TEST_CMD, "--kubeconfig", TEST_CONFIG,
             "--namespace", TEST_NAMESPACE, "get", "events");
         assertEquals(expectedCommand, listCaptor.getValue());
@@ -359,12 +359,12 @@ class BaseCmdKubeClientTest {
     void testCreateNamespace() {
         String namespaceName = "new-ns";
         ExecResult mockResult = mockSuccessfulExecResult("namespace/new-ns created");
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         client.createNamespace(namespaceName);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedParts = Arrays.asList(TEST_CMD, "--kubeconfig", TEST_CONFIG,
             "--namespace", TEST_NAMESPACE, "create", "namespace", namespaceName);
@@ -401,7 +401,7 @@ class BaseCmdKubeClientTest {
         client.scaleByName(kind, name, replicas);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(isNull(), listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedParts = Arrays.asList("scale", kind, name, "--replicas", String.valueOf(replicas));
         assertTrue(capturedCommand.containsAll(expectedParts));
@@ -553,13 +553,13 @@ class BaseCmdKubeClientTest {
         String resourceType = "pods";
         String output = "pod-a pod-b  pod-c";
         ExecResult mockResult = mockSuccessfulExecResult(output);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         List<String> resources = client.list(resourceType);
 
         assertEquals(Arrays.asList("pod-a", "pod-b", "pod-c"), resources);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedParts = Arrays.asList("get", resourceType,
             "-o", "jsonpath={range .items[*]}{.metadata.name} ");
         assertTrue(listCaptor.getValue().containsAll(expectedParts));
@@ -570,7 +570,7 @@ class BaseCmdKubeClientTest {
         String resourceType = "deployments";
         String output = " ";
         ExecResult mockResult = mockSuccessfulExecResult(output);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         List<String> resources = client.list(resourceType);
 
@@ -584,12 +584,12 @@ class BaseCmdKubeClientTest {
         String name = "my-cm";
         String jsonOutput = "{\"kind\": \"ConfigMap\"}";
         ExecResult mockResult = mockSuccessfulExecResult(jsonOutput);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         String result = client.getResourceAsJson(type, name);
         assertEquals(jsonOutput, result);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedParts = Arrays.asList("get", type, name, "-o", "json");
         assertTrue(listCaptor.getValue().containsAll(expectedParts));
     }
@@ -601,12 +601,12 @@ class BaseCmdKubeClientTest {
         String name = "my-secret";
         String yamlOutput = "kind: Secret";
         ExecResult mockResult = mockSuccessfulExecResult(yamlOutput);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         String result = client.getResourceAsYaml(type, name);
         assertEquals(yamlOutput, result);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedParts = Arrays.asList("get", type, name, "-o", "yaml");
         assertTrue(listCaptor.getValue().containsAll(expectedParts));
     }
@@ -617,12 +617,12 @@ class BaseCmdKubeClientTest {
         String type = "ingresses";
         String yamlOutput = "kind: List\nitems:\n- kind: Ingress";
         ExecResult mockResult = mockSuccessfulExecResult(yamlOutput);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         String result = client.getResourcesAsYaml(type);
         assertEquals(yamlOutput, result);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedParts = Arrays.asList("get", type, "-o", "yaml");
         assertTrue(listCaptor.getValue().containsAll(expectedParts));
     }
@@ -638,7 +638,7 @@ class BaseCmdKubeClientTest {
         ExecResult applyResult = mockSuccessfulExecResult("applied");
 
         ArgumentCaptor<List<String>> processCmdCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.when(() -> Exec.exec(processCmdCaptor.capture())).thenReturn(processResult);
+        mockedExec.when(() -> Exec.exec(processCmdCaptor.capture(), eq(0))).thenReturn(processResult);
 
         ArgumentCaptor<List<String>> applyCmdCaptor = ArgumentCaptor.forClass(List.class);
         mockedExec.when(() -> Exec.exec(eq(processedYaml), applyCmdCaptor.capture(), eq(0), eq(true), eq(true)))
@@ -665,12 +665,12 @@ class BaseCmdKubeClientTest {
         String name = "node01";
         String description = "Name: node01\nRoles: worker";
         ExecResult mockResult = mockSuccessfulExecResult(description);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         String result = client.describe(type, name);
         assertEquals(description, result);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedParts = Arrays.asList("describe", type, name);
         assertTrue(listCaptor.getValue().containsAll(expectedParts));
     }
@@ -681,12 +681,12 @@ class BaseCmdKubeClientTest {
         String podName = "log-pod";
         String logOutput = "Log line 1\nLog line 2";
         ExecResult mockResult = mockSuccessfulExecResult(logOutput);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         String logs = client.logs(podName, null);
         assertEquals(logOutput, logs);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         assertTrue(listCaptor.getValue().containsAll(Arrays.asList("logs", podName)));
         assertFalse(listCaptor.getValue().contains("-c"));
     }
@@ -698,12 +698,12 @@ class BaseCmdKubeClientTest {
         String containerName = "log-container";
         String logOutput = "Container log 1";
         ExecResult mockResult = mockSuccessfulExecResult(logOutput);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         String logs = client.logs(podName, containerName);
         assertEquals(logOutput, logs);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedParts = Arrays.asList("logs", podName, "-c", containerName);
         assertTrue(listCaptor.getValue().containsAll(expectedParts));
     }
@@ -714,12 +714,12 @@ class BaseCmdKubeClientTest {
         String podName = "log-pod-cont";
         String logOutput = "Container log 1";
         ExecResult mockResult = mockSuccessfulExecResult(logOutput);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         String logs = client.previousLogs(podName);
         assertEquals(logOutput, logs);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedParts = Arrays.asList("logs", podName, "--previous=true");
         assertTrue(listCaptor.getValue().containsAll(expectedParts));
     }
@@ -731,12 +731,12 @@ class BaseCmdKubeClientTest {
         String containerName = "log-container";
         String logOutput = "Container log 1";
         ExecResult mockResult = mockSuccessfulExecResult(logOutput);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         String logs = client.previousLogs(podName, containerName);
         assertEquals(logOutput, logs);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedParts = Arrays.asList("logs", podName, "-c", containerName, "--previous=true");
         assertTrue(listCaptor.getValue().containsAll(expectedParts));
     }
@@ -750,13 +750,13 @@ class BaseCmdKubeClientTest {
         String logMatch = "Previous line\nERROR: Something went wrong";
 
         ExecResult mockResult = mockSuccessfulExecResult(logMatch);
-        mockedExec.when(() -> Exec.exec(eq("bash"), eq("-c"), anyString())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(eq(0), eq("bash"), eq("-c"), anyString())).thenReturn(mockResult);
 
         String result = client.searchInLog(resourceType, resourceName, sinceSeconds, grepPattern);
         assertEquals(logMatch, result);
 
         ArgumentCaptor<String> bashCmdCaptor = ArgumentCaptor.forClass(String.class);
-        mockedExec.verify(() -> Exec.exec(eq("bash"), eq("-c"), bashCmdCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(eq(0), eq("bash"), eq("-c"), bashCmdCaptor.capture()));
         String capturedBashCmd = bashCmdCaptor.getValue();
 
         assertTrue(capturedBashCmd.contains(TEST_CMD));
@@ -777,7 +777,8 @@ class BaseCmdKubeClientTest {
         lenient().when(failedGrepResult.out()).thenReturn("");
 
         KubeClusterException kubeException = new KubeClusterException(failedGrepResult, "Grep failed");
-        mockedExec.when(() -> Exec.exec(eq("bash"), eq("-c"), anyString())).thenThrow(kubeException);
+        mockedExec.when(() -> Exec.exec(eq(0), eq("bash"), eq("-c"), anyString()))
+            .thenThrow(kubeException);
 
         String result = client.searchInLog(resourceType, resourceName, sinceSeconds, grepPattern);
         assertEquals("", result);
@@ -795,7 +796,8 @@ class BaseCmdKubeClientTest {
         lenient().when(errorResult.err()).thenReturn("Command not found or other error");
 
         KubeClusterException kubeException = new KubeClusterException(errorResult, "Exec error");
-        mockedExec.when(() -> Exec.exec(eq("bash"), eq("-c"), anyString())).thenThrow(kubeException);
+        mockedExec.when(() -> Exec.exec(eq(0), eq("bash"), eq("-c"), anyString()))
+            .thenThrow(kubeException);
 
         String result = client.searchInLog(resourceType, resourceName, sinceSeconds, grepPattern);
         assertEquals("", result);
@@ -811,14 +813,15 @@ class BaseCmdKubeClientTest {
         String logMatch = "Context line\nWarning: Low disk space";
 
         ExecResult mockResult = mockSuccessfulExecResult(logMatch);
-        mockedExec.when(() -> Exec.exec(eq("bash"), eq("-c"), anyString())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(eq(0), eq("bash"), eq("-c"), anyString()))
+            .thenReturn(mockResult);
 
         String result = client.searchInLog(resourceType, resourceName, resourceContainer,
             sinceSeconds, grepPattern);
         assertEquals(logMatch, result);
 
         ArgumentCaptor<String> bashCmdCaptor = ArgumentCaptor.forClass(String.class);
-        mockedExec.verify(() -> Exec.exec(eq("bash"), eq("-c"), bashCmdCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(eq(0), eq("bash"), eq("-c"), bashCmdCaptor.capture()));
         String capturedBashCmd = bashCmdCaptor.getValue();
 
         String expectedLogCmd = "logs " + resourceType + "/" + resourceName + " -c " + resourceContainer;
@@ -834,12 +837,12 @@ class BaseCmdKubeClientTest {
         String label = "app=my-app";
         String output = "service-a service-b";
         ExecResult mockResult = mockSuccessfulExecResult(output);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         List<String> resources = client.listResourcesByLabel(resourceType, label);
         assertEquals(Arrays.asList("service-a", "service-b"), resources);
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> expectedParts = Arrays.asList("get", resourceType, "-l", label,
             "-o", "jsonpath={range .items[*]}{.metadata.name} ");
         assertTrue(listCaptor.getValue().containsAll(expectedParts));

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/KubectlTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/KubectlTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
@@ -107,15 +108,15 @@ class KubectlTest {
     void testGetUsernameConstructsCommandAndReturnsOutput() {
         String expectedUsername = "system:serviceaccount:kube-system:default";
         ExecResult mockResult = mockSuccessfulExecResult(expectedUsername);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(10))).thenReturn(mockResult);
 
-        Kubectl client = new Kubectl(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
+        Kubectl client = new Kubectl(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE).withTimeout(10);
         String actualUsername = client.getUsername();
 
         assertEquals(expectedUsername, actualUsername);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(10)));
 
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedCommandParts = Arrays.asList(
@@ -132,13 +133,13 @@ class KubectlTest {
     void testCordonConstructsCorrectCommand() {
         String nodeName = "node-01";
         ExecResult mockResult = mockSuccessfulExecResult("");
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         Kubectl client = new Kubectl(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
         client.cordon(nodeName);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedCommandParts = Arrays.asList(
             Kubectl.KUBECTL,
@@ -154,13 +155,13 @@ class KubectlTest {
     void testUncordonConstructsCorrectCommand() {
         String nodeName = "node-02";
         ExecResult mockResult = mockSuccessfulExecResult("");
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         Kubectl client = new Kubectl(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
         client.uncordon(nodeName);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedCommandParts = Arrays.asList(
             Kubectl.KUBECTL,
@@ -180,13 +181,13 @@ class KubectlTest {
         long timeoutInSeconds = 300;
 
         ExecResult mockResult = mockSuccessfulExecResult("");
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         Kubectl client = new Kubectl(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
         client.drain(nodeName, ignoreDaemonSets, disableEviction, timeoutInSeconds);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> capturedCommand = listCaptor.getValue();
 
         List<String> expectedCommandParts = Arrays.asList(
@@ -209,7 +210,7 @@ class KubectlTest {
         String expectedYaml = "apiVersion: v1\nkind: Pod...";
         ExecResult mockResult = mockSuccessfulExecResult(expectedYaml);
 
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         Kubectl client = new Kubectl(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
         String actualYaml = client.get(resourceType, resourceName);
@@ -217,7 +218,7 @@ class KubectlTest {
         assertEquals(expectedYaml, actualYaml);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> capturedCommand = listCaptor.getValue();
 
         assertTrue(capturedCommand.contains(Kubectl.KUBECTL), "Command should use 'kubectl'");

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/OcTest.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/OcTest.java
@@ -113,14 +113,15 @@ class OcTest {
         String namespaceName = "my-new-project";
         ExecResult mockResult = mockSuccessfulExecResult(""); // new-project might not output much on success
         // Exec.exec(cmd(), "new-project", name);
-        mockedExec.when(() -> Exec.exec(eq(OC_CMD), eq("new-project"), eq(namespaceName)))
+        mockedExec.when(() -> Exec.exec(eq(0), eq(OC_CMD), eq("new-project"), eq(namespaceName)))
             .thenReturn(mockResult);
 
-        Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE); // Namespace is not used by this call
+        Oc client = new Oc(CUSTOM_CONFIG)
+            .inNamespace(DEFAULT_NAMESPACE).withTimeout(0); // Namespace is not used by this call
         client.createNamespace(namespaceName);
 
         // Verify the specific call for oc createNamespace
-        mockedExec.verify(() -> Exec.exec(OC_CMD, "new-project", namespaceName));
+        mockedExec.verify(() -> Exec.exec(0, OC_CMD, "new-project", namespaceName));
     }
 
     @Test
@@ -129,13 +130,13 @@ class OcTest {
         String templateName = "my-template";
         Map<String, String> params = Map.of("PARAM1", "VALUE1", "PARAM2", "VALUE2");
         ExecResult mockResult = mockSuccessfulExecResult("Application created");
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(5))).thenReturn(mockResult);
 
-        Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
+        Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE).withTimeout(5);
         client.newApp(templateName, params);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(5)));
         List<String> capturedCommand = listCaptor.getValue();
 
         List<String> expectedBase = new ArrayList<>(Arrays.asList(
@@ -170,13 +171,13 @@ class OcTest {
         String templateName = "simple-template";
         Map<String, String> params = Collections.emptyMap();
         ExecResult mockResult = mockSuccessfulExecResult("Application created");
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
         client.newApp(templateName, params);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> capturedCommand = listCaptor.getValue();
 
         List<String> expectedCommandParts = Arrays.asList(
@@ -193,15 +194,15 @@ class OcTest {
     void testGetUsernameConstructsOcCommandAndReturnsOutput() {
         String expectedUsername = "testuser";
         ExecResult mockResult = mockSuccessfulExecResult(expectedUsername);
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(10))).thenReturn(mockResult);
 
-        Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
+        Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE).withTimeout(10);
         String actualUsername = client.getUsername();
 
         assertEquals(expectedUsername, actualUsername);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(10)));
 
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedCommandParts = Arrays.asList(
@@ -218,13 +219,13 @@ class OcTest {
     void testCordonConstructsOcAdmCommand() {
         String nodeName = "oc-node-01";
         ExecResult mockResult = mockSuccessfulExecResult("");
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
         client.cordon(nodeName);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedCommandParts = Arrays.asList(
             OC_CMD,
@@ -240,13 +241,13 @@ class OcTest {
     void testUncordonConstructsOcAdmCommand() {
         String nodeName = "oc-node-02";
         ExecResult mockResult = mockSuccessfulExecResult("");
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(0))).thenReturn(mockResult);
 
         Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
         client.uncordon(nodeName);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(0)));
         List<String> capturedCommand = listCaptor.getValue();
         List<String> expectedCommandParts = Arrays.asList(
             OC_CMD,
@@ -266,13 +267,13 @@ class OcTest {
         long timeoutInSeconds = 60;
 
         ExecResult mockResult = mockSuccessfulExecResult("");
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(10))).thenReturn(mockResult);
 
-        Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
+        Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE).withTimeout(10);
         client.drain(nodeName, ignoreDaemonSets, disableEviction, timeoutInSeconds);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(10)));
         List<String> capturedCommand = listCaptor.getValue();
 
         List<String> expectedCommandParts = Arrays.asList(
@@ -295,15 +296,15 @@ class OcTest {
         String expectedYaml = "apiVersion: route.openshift.io/v1\nkind: Route...";
         ExecResult mockResult = mockSuccessfulExecResult(expectedYaml);
 
-        mockedExec.when(() -> Exec.exec(anyList())).thenReturn(mockResult);
+        mockedExec.when(() -> Exec.exec(anyList(), eq(6))).thenReturn(mockResult);
 
-        Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE);
+        Oc client = new Oc(CUSTOM_CONFIG).inNamespace(DEFAULT_NAMESPACE).withTimeout(6);
         String actualYaml = client.get(resourceType, resourceName);
 
         assertEquals(expectedYaml, actualYaml);
 
         ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass(List.class);
-        mockedExec.verify(() -> Exec.exec(listCaptor.capture()));
+        mockedExec.verify(() -> Exec.exec(listCaptor.capture(), eq(6)));
         List<String> capturedCommand = listCaptor.getValue();
 
         assertTrue(capturedCommand.contains(OC_CMD), "Command should use 'oc'");

--- a/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/TestableCmdKubeClient.java
+++ b/test-frame-common/src/test/java/io/skodjob/testframe/clients/cmdClient/TestableCmdKubeClient.java
@@ -9,7 +9,7 @@ public class TestableCmdKubeClient extends BaseCmdKubeClient<TestableCmdKubeClie
     private final String commandName;
 
     public TestableCmdKubeClient(String commandName, String config) {
-        super(config);
+        super(config, 0);
         this.commandName = commandName;
     }
 
@@ -24,6 +24,11 @@ public class TestableCmdKubeClient extends BaseCmdKubeClient<TestableCmdKubeClie
 
     @Override
     public KubeCmdClient<TestableCmdKubeClient> inNamespace(String namespace) {
+        return null;
+    }
+
+    @Override
+    public KubeCmdClient<TestableCmdKubeClient> withTimeout(int timeout) {
         return null;
     }
 

--- a/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
+++ b/test-frame-test-examples/src/test/java/io/skodjob/testframe/test/integration/KubeResourceManagerCleanerIT.java
@@ -91,4 +91,10 @@ final class KubeResourceManagerCleanerIT extends AbstractIT {
         }
         assertTrue(KubeResourceManager.get().kubeClient().namespaceExists("kornys"));
     }
+
+    @Test
+    void testKubeCmdWithTimeout() {
+        assertTrue(KubeResourceManager.get().kubeCmdClient().inNamespace("default").withTimeout(10_000)
+            .exec("get", "secrets").exitStatus());
+    }
 }


### PR DESCRIPTION
## Description

Ability to configure timeout for kubectl or oc command. Default is 0 which is infinity wait


## Type of Change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/integration tests pass locally with my changes
