### PR TITLE
Change build matrix to use java 24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [17, 21, 23]
+        version: [17, 21, 24]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

Upgrade github build matrix to jdk 24


## Type of Change

Please delete options that are not relevant.

* Update (Update version or update existing automation)

