### PR TITLE
Allow to configure timeout for kubectl as long or int

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/KubeCmdClient.java
@@ -46,12 +46,20 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
 
 
     /**
-     * Sets the timeout for subsequent operations.
+     * Sets the timeout for later operations.
      *
-     * @param timeout timeout for execution of command.
+     * @param timeout timeout in ms for execution of command.
      * @return This kube client.
      */
     KubeCmdClient<K> withTimeout(int timeout);
+
+    /**
+     * Sets the timeout for later operations.
+     *
+     * @param timeout timeout in ms for execution of command.
+     * @return This kube client.
+     */
+    KubeCmdClient<K> withTimeout(long timeout);
 
     /**
      * Retrieves the currently set namespace for the Kubernetes client.

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Kubectl.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Kubectl.java
@@ -60,6 +60,17 @@ public class Kubectl extends BaseCmdKubeClient<Kubectl> {
     }
 
     /**
+     * Sets the timeout for subsequent operations.
+     *
+     * @param timeout timeout for execution of command.
+     * @return This kube client.
+     */
+    @Override
+    public Kubectl withTimeout(long timeout) {
+        return new Kubectl(namespace, config, (int) timeout);
+    }
+
+    /**
      * Gets the current namespace of the Kubectl instance.
      *
      * @return The current namespace.

--- a/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Oc.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/clients/cmdClient/Oc.java
@@ -62,14 +62,25 @@ public class Oc extends BaseCmdKubeClient<Oc> {
     }
 
     /**
-     * Sets the timeout for subsequent operations.
+     * Sets the timeout for later operations.
      *
-     * @param timeout timeout for execution of command.
+     * @param timeout timeout in ms for execution of command.
      * @return This kube client.
      */
     @Override
     public Oc withTimeout(int timeout) {
         return new Oc(namespace, config, timeout);
+    }
+
+    /**
+     * Sets the timeout for later operations.
+     *
+     * @param timeout timeout in ms for execution of command.
+     * @return This kube client.
+     */
+    @Override
+    public Oc withTimeout(long timeout) {
+        return new Oc(namespace, config, (int) timeout);
     }
 
     /**


### PR DESCRIPTION
## Description

Add api for config timeout in ms as long data type


## Type of Change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)
