### PR TITLE
Check if exception's cause is null or not in `Wait` class

### DIFF
--- a/test-frame-common/src/main/java/io/skodjob/testframe/wait/Wait.java
+++ b/test-frame-common/src/main/java/io/skodjob/testframe/wait/Wait.java
@@ -93,8 +93,11 @@ public class Wait {
                             description, e.getCause().getClass().getCanonicalName());
                         exceptionMessage = e.getCause().getClass().getCanonicalName();
                     } else {
+                        String canonicalNameForException = e.getCause() != null ?
+                            e.getCause().getClass().getCanonicalName() : null;
+
                         LOGGER.warn("While waiting for: {} exception occurred: {}/{}",
-                            description, e.getCause().getClass().getCanonicalName(), exceptionMessage);
+                            description, canonicalNameForException, exceptionMessage);
                     }
 
                     // log the stacktrace


### PR DESCRIPTION
## Description

Currently when we catch some exception during _wait_ we immediately log warning message that some exception was caught while waiting for something.
This works fine in most scenarios, but in case that the `cause` is `null`, we get NPE in the log - which eventually hides the real exception and fail the whole wait eventually.

This PR adds just a small check for presence of the `cause` in the exception and based on that prints the "canonical name".

## Type of Change

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit/integration tests pass locally with my changes
