### PR TITLE
Update build matrix to LTS java25

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [17, 21, 24]
+        version: [17, 21, 25]
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Description

Add LTS java 25 to build matrix instead of 24


## Type of Change

Please delete options that are not relevant.

* Update (Update version or update existing automation)
